### PR TITLE
Model configs pass attributes to PretrainedConfig to prevent override…

### DIFF
--- a/lib/python/EasyDel/modules/falcon/falcon_configuration.py
+++ b/lib/python/EasyDel/modules/falcon/falcon_configuration.py
@@ -72,6 +72,7 @@ class FalconConfig(EasyDelPretrainedConfig):
             axis_names=axis_names,
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
+            bits=bits,
             **kwargs
         )
 

--- a/lib/python/EasyDel/modules/gemma/gemma_configuration.py
+++ b/lib/python/EasyDel/modules/gemma/gemma_configuration.py
@@ -66,6 +66,7 @@ class GemmaConfig(EasyDelPretrainedConfig):
             eos_token_id=eos_token_id,
             pad_token_id=pad_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            bits=bits,
             **kwargs,
         )
 

--- a/lib/python/EasyDel/modules/gpt2/gpt2_configuration.py
+++ b/lib/python/EasyDel/modules/gpt2/gpt2_configuration.py
@@ -77,6 +77,7 @@ class GPT2Config(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            bits=bits,
             **kwargs
         )
 

--- a/lib/python/EasyDel/modules/gpt_j/gpt_j_configuration.py
+++ b/lib/python/EasyDel/modules/gpt_j/gpt_j_configuration.py
@@ -66,6 +66,7 @@ class GPTJConfig(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            bits=bits,
             **kwargs
         )
 

--- a/lib/python/EasyDel/modules/llama/llama_configuration.py
+++ b/lib/python/EasyDel/modules/llama/llama_configuration.py
@@ -115,6 +115,8 @@ class LlamaConfig(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            scan_mlp_chunk_size=scan_mlp_chunk_size,
+            bits=bits,
             **kwargs,
         )
 

--- a/lib/python/EasyDel/modules/mistral/mistral_configuration.py
+++ b/lib/python/EasyDel/modules/mistral/mistral_configuration.py
@@ -108,6 +108,9 @@ class MistralConfig(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            use_scan_mlp=use_scan_mlp,
+            scan_mlp_chunk_size=scan_mlp_chunk_size,
+            bits=bits,
             **kwargs,
         )
 

--- a/lib/python/EasyDel/modules/mixtral/mixtral_configuration.py
+++ b/lib/python/EasyDel/modules/mixtral/mixtral_configuration.py
@@ -122,6 +122,9 @@ class MixtralConfig(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            use_scan_mlp=use_scan_mlp,
+            scan_mlp_chunk_size=scan_mlp_chunk_size,
+            bits=bits,
             **kwargs,
         )
 

--- a/lib/python/EasyDel/modules/mosaic_mpt/mosaic_configuration.py
+++ b/lib/python/EasyDel/modules/mosaic_mpt/mosaic_configuration.py
@@ -65,6 +65,7 @@ class MptConfig(EasyDelPretrainedConfig):
         if 'loss_fn' in kwargs:
             del kwargs['loss_fn']
         super().__init__(
+            bits=bits,
             **kwargs
         )
 

--- a/lib/python/EasyDel/modules/phi/phi_configuration.py
+++ b/lib/python/EasyDel/modules/phi/phi_configuration.py
@@ -74,6 +74,7 @@ class PhiConfig(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            bits=bits,
             **kwargs
         )
 

--- a/lib/python/EasyDel/modules/qwen1/qwen1_configuration.py
+++ b/lib/python/EasyDel/modules/qwen1/qwen1_configuration.py
@@ -67,6 +67,9 @@ class Qwen1Config(EasyDelPretrainedConfig):
         self.bits = bits
         super().__init__(
             tie_word_embeddings=tie_word_embeddings,
+            use_scan_mlp=use_scan_mlp,
+            scan_mlp_chunk_size=scan_mlp_chunk_size,
+            bits=bits,
             **kwargs,
         )
 

--- a/lib/python/EasyDel/modules/qwen2/qwen_configuration.py
+++ b/lib/python/EasyDel/modules/qwen2/qwen_configuration.py
@@ -76,6 +76,9 @@ class Qwen2Config(EasyDelPretrainedConfig):
         self.bits = bits
         super().__init__(
             tie_word_embeddings=tie_word_embeddings,
+            use_scan_mlp=use_scan_mlp,
+            scan_mlp_chunk_size=scan_mlp_chunk_size,
+            bits=bits,
             **kwargs,
         )
 

--- a/lib/python/EasyDel/modules/rwkv/rwkv_configuration.py
+++ b/lib/python/EasyDel/modules/rwkv/rwkv_configuration.py
@@ -48,7 +48,11 @@ class RwkvConfig(EasyDelPretrainedConfig):
         self.eos_token_id = eos_token_id
 
         super().__init__(
-            tie_word_embeddings=tie_word_embeddings, bos_token_id=bos_token_id, eos_token_id=eos_token_id, **kwargs
+            tie_word_embeddings=tie_word_embeddings,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            bits=bits,
+            **kwargs
         )
 
     def add_jax_args(

--- a/lib/python/EasyDel/modules/stablelm/stablelm_configuration.py
+++ b/lib/python/EasyDel/modules/stablelm/stablelm_configuration.py
@@ -66,6 +66,7 @@ class StableLmConfig(EasyDelPretrainedConfig):
             bos_token_id=bos_token_id,
             eos_token_id=eos_token_id,
             tie_word_embeddings=tie_word_embeddings,
+            bits=bits,
             **kwargs
         )
 

--- a/python_test/easy_causal_language_model_trainer_test.py
+++ b/python_test/easy_causal_language_model_trainer_test.py
@@ -27,6 +27,7 @@ def main():
         intermediate_size=256,
         gradient_checkpointing="",
         max_position_embeddings=sequence_length,
+        use_scan_mlp=False,
     )
 
     model = FlaxQwen2ForCausalLM(config=config, _do_init=True)


### PR DESCRIPTION
… with default

Without this fix, setting e.g. use_scan_mlp to False in Qwen2Config would have no effect, since it was not passed to EasyDelPretrainedConfig, which would then set it to its default True value. Same for the other arguments that could be overwritten by EasyDelPretrainedConfig and other models like Mistral.