### PR TITLE
Ignore token label smooth z loss

### DIFF
--- a/lib/python/EasyDel/modules/llama/modelling_llama_flax.py
+++ b/lib/python/EasyDel/modules/llama/modelling_llama_flax.py
@@ -885,10 +885,10 @@ class FlaxLlamaModule(nn.Module):
                 rope_type=scaling_type
             )
         self.freq_cis = precompute_freq_cis(
-            max_position_embeddings=getattr(
-                self.config,
-                "freq_max_position_embeddings",
-                self.config.max_position_embeddings
+            max_position_embeddings=(
+                self.config.freq_max_position_embeddings
+                if self.config.freq_max_position_embeddings is not None
+                else self.config.max_position_embeddings
             ),
             dim=config.hidden_size // config.num_attention_heads,
             base=config.rope_theta,

--- a/lib/python/EasyDel/modules/mistral/modelling_mistral_flax.py
+++ b/lib/python/EasyDel/modules/mistral/modelling_mistral_flax.py
@@ -835,10 +835,10 @@ class FlaxMistralModule(nn.Module):
                 rope_type=scaling_type
             )
         self.freq_cis = precompute_freq_cis(
-            max_position_embeddings=getattr(
-                self.config,
-                "freq_max_position_embeddings",
-                self.config.max_position_embeddings
+            max_position_embeddings=(
+                self.config.freq_max_position_embeddings
+                if self.config.freq_max_position_embeddings is not None
+                else self.config.max_position_embeddings
             ),
             dim=self.config.hidden_size // self.config.num_attention_heads,
             base=self.config.rope_theta,

--- a/lib/python/EasyDel/modules/mixtral/modelling_mixtral_flax.py
+++ b/lib/python/EasyDel/modules/mixtral/modelling_mixtral_flax.py
@@ -957,10 +957,10 @@ class FlaxMixtralModule(nn.Module):
                 rope_type=scaling_type
             )
         self.freq_cis = precompute_freq_cis(
-            max_position_embeddings=getattr(
-                self.config,
-                "freq_max_position_embeddings",
-                self.config.max_position_embeddings
+            max_position_embeddings=(
+                self.config.freq_max_position_embeddings
+                if self.config.freq_max_position_embeddings is not None
+                else self.config.max_position_embeddings
             ),
             dim=self.config.hidden_size // self.config.num_attention_heads,
             base=self.config.rope_theta,

--- a/lib/python/EasyDel/modules/phi/modelling_phi_flax.py
+++ b/lib/python/EasyDel/modules/phi/modelling_phi_flax.py
@@ -598,10 +598,10 @@ class FlaxPhiModule(nn.Module):
                     rope_type=scaling_type
                 )
         self.freq_cis = precompute_freq_cis(
-            max_position_embeddings=getattr(
-                self.config,
-                "freq_max_position_embeddings",
-                self.config.max_position_embeddings
+            max_position_embeddings=(
+                self.config.freq_max_position_embeddings
+                if self.config.freq_max_position_embeddings is not None
+                else self.config.max_position_embeddings
             ),
             dim=int(config.partial_rotary_factor * (config.hidden_size // config.num_attention_heads)),
             # dim=config.hidden_size // config.num_attention_heads,

--- a/lib/python/EasyDel/modules/qwen2/modelling_qwen_flax.py
+++ b/lib/python/EasyDel/modules/qwen2/modelling_qwen_flax.py
@@ -883,7 +883,11 @@ class FlaxQwen2Module(nn.Module):
                 rope_type=scaling_type
             )
         self.freq_cis = precompute_freq_cis(
-            max_position_embeddings=getattr(config, "freq_max_position_embeddings", config.max_position_embeddings),
+            max_position_embeddings=(
+                self.config.freq_max_position_embeddings
+                if self.config.freq_max_position_embeddings is not None
+                else self.config.max_position_embeddings
+            ),
             dim=config.hidden_size // config.num_attention_heads,
             base=config.rope_theta,
             **initial_rope_kwargs

--- a/lib/python/EasyDel/modules/stablelm/modelling_stablelm_flax.py
+++ b/lib/python/EasyDel/modules/stablelm/modelling_stablelm_flax.py
@@ -651,10 +651,10 @@ class FlaxStableLmModule(nn.Module):
                     rope_type=scaling_type
                 )
         self.freq_cis = precompute_freq_cis(
-            max_position_embeddings=getattr(
-                self.config,
-                "freq_max_position_embeddings",
-                self.config.max_position_embeddings
+            max_position_embeddings=(
+                self.config.freq_max_position_embeddings
+                if self.config.freq_max_position_embeddings is not None
+                else self.config.max_position_embeddings
             ),
             dim=int(config.partial_rotary_factor * (config.hidden_size // config.num_attention_heads)),
             # dim=config.hidden_size // config.num_attention_heads,

--- a/lib/python/EasyDel/trainer/base_trainer.py
+++ b/lib/python/EasyDel/trainer/base_trainer.py
@@ -228,6 +228,7 @@ class BaseTrainer:
         self.create_sharded_state_from_params_function = \
             function_configurations.create_sharded_state_from_params_function
         self.sharded_train_step_function = function_configurations.sharded_train_step_function
+        self.sharded_eval_step_function = function_configurations.sharded_eval_step_function
         self.mesh = function_configurations.mesh
         self.checkpoint_manager = function_configurations.checkpoint_manager
         self.initialize_state_function = function_configurations.initialize_state_function

--- a/lib/python/EasyDel/trainer/training_configurations.py
+++ b/lib/python/EasyDel/trainer/training_configurations.py
@@ -63,6 +63,8 @@ class TrainArguments(
             learning_rate_end: Optional[float] = 5e-6,
             gradient_accumulation_steps: int = 1,
             weight_decay: float = 0.01,
+            label_smoothing_factor: float = 0.0,
+            z_loss: float = 0.0,
             gradient_checkpointing: AVAILABLE_GRADIENT_CHECKPOINTS = EasyDelGradientCheckPointers.NOTHING_SAVEABLE,
             max_sequence_length: Optional[int] = 4096,
             sharding_array: Union[tuple, int] = (1, -1, 1, 1),
@@ -70,6 +72,7 @@ class TrainArguments(
             do_train: bool = True,
             do_eval: bool = False,
             do_test: Optional[bool] = False,
+            train_on_inputs: bool = True,
             backend: Optional[str] = None,
             extra_optimizer_kwargs: dict = None,
             save_steps: Optional[int] = None,
@@ -129,6 +132,8 @@ class TrainArguments(
     :param learning_rate_end: Optional[float]: Set the learning rate at the end of training
     :param gradient_accumulation_steps: int: Accumulate gradients over multiple batches
     :param weight_decay: float: Specify the weight decay to be used by the optimizer
+    :param label_smoothing_factor: float: Set the label smoothing factor to be used by the loss function
+    :param z_loss: float: Set the z loss factor to be used by the loss function
     :param gradient_checkpointing: AVAILABLE_GRADIENT_CHECKPOINTS: Determine how to use gradient checkpointing
     :param max_sequence_length: Optional[int]: Set the maximum length of the input sequence
     :param sharding_array: Union[tuple,int]: Specify the mesh of devices to use for training
@@ -136,6 +141,7 @@ class TrainArguments(
     :param do_train: bool: Indicate whether to train the model or not
     :param do_eval: bool: Determine whether to run evaluation on the validation set after training
     :param do_test: Optional[bool]: Determine if the model should be tested
+    :param train_on_inputs: bool: Use input_ids instead of labels, overrides ignored (-100) tokens in the labels
     :param backend: Optional[str]: Specify the backend of jax
     :param extra_optimizer_kwargs: dict: Pass extra arguments to the optimizer
     :param save_steps: Optional[int]: Save the model after every n steps
@@ -236,6 +242,8 @@ class TrainArguments(
         self.learning_rate = learning_rate
         self.learning_rate_end = learning_rate_end
         self.weight_decay = weight_decay
+        self.label_smoothing_factor = label_smoothing_factor
+        self.z_loss = z_loss
         self.model_name = model_name
         self.gradient_checkpointing = gradient_checkpointing
         self.max_sequence_length = max_sequence_length
@@ -244,6 +252,7 @@ class TrainArguments(
         self.do_train = do_train
         self.do_eval = do_eval
         self.do_test = do_test
+        self.train_on_inputs = train_on_inputs
         self.save_steps = save_steps
         self.save_dir = save_dir
         self.use_pjit_attention_force = use_pjit_attention_force

--- a/python_test/easy_mistral_clm_trainer_test.py
+++ b/python_test/easy_mistral_clm_trainer_test.py
@@ -1,0 +1,83 @@
+import os
+
+import flax.core
+
+from EasyDel import Qwen2Config
+
+os.environ["JAX_TRACEBACK_FILTERING"] = "off"
+
+from lib.python.EasyDel import (
+    CausalLanguageModelTrainer,
+    AutoEasyDelModelForCausalLM,
+    TrainArguments,
+    FlaxMistralForCausalLM,
+    MistralConfig
+)
+from jax import numpy as jnp, random
+from datasets import Dataset
+
+
+def main():
+    sequence_length = 128
+    data_row_size = 100
+    config = MistralConfig(
+        hidden_size=128,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+        num_hidden_layers=4,
+        intermediate_size=256,
+        gradient_checkpointing="",
+        max_position_embeddings=sequence_length,
+    )
+
+    model = FlaxMistralForCausalLM(config=config, _do_init=True)
+    params = model.params
+
+    def data_generator():
+        for i in range(data_row_size):
+            yield {
+                "attention_mask": jnp.ones(
+                    (1, sequence_length), dtype="i4"
+                ),
+                "input_ids": random.randint(
+                    random.PRNGKey(0), (1, sequence_length), 0, 32000, dtype="i4"
+                )
+            }
+
+    example_data = Dataset.from_generator(data_generator, )
+    dtype = jnp.float32
+    trainer = CausalLanguageModelTrainer(
+        arguments=TrainArguments(
+            model_name="MistralSmoothZlossTest",
+            num_train_epochs=3,
+            total_batch_size=2,
+            gradient_accumulation_steps=2,
+            use_wandb=False,
+            model_class=type(model),
+            do_shard_fns=False,
+            do_train=True,
+            do_eval=True,
+            max_sequence_length=sequence_length,
+            configs_to_initialize_model_class={
+                "config": model.config,
+                "input_shape": (1, 1),
+                "dtype": dtype,
+                "param_dtype": dtype
+            },
+            dtype=dtype,
+            param_dtype=dtype,
+            track_memory=False,
+            learning_rate=5e-4,
+            label_smoothing_factor=0.1,
+            z_loss=0.0001,
+            train_on_inputs=True,
+        ),
+        dataset_train=example_data,
+        dataset_eval=example_data,
+    )
+
+    trainer.train(model_parameters=flax.core.FrozenDict({"params": params}))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds the ability to ignore tokens during loss calculation (override with train_on_inputs=True), label smoothing and a z_loss regularization factor.
Also two commits with fixes required after rebasing this patch onto latest main.
