### PR TITLE
Add support for iterable dataset loading

### DIFF
--- a/lib/python/EasyDel/trainer/causal_language_model_trainer/causal_language_model_trainer.py
+++ b/lib/python/EasyDel/trainer/causal_language_model_trainer/causal_language_model_trainer.py
@@ -418,9 +418,11 @@ class CausalLanguageModelTrainer(BaseTrainer):
                 )
                 wandb.summary["Number of Model Parameters (Billion)"] = model_parameters_number
             try:
+                train_iter = iter(self.dataloader_train)
                 for epoch in range(self.arguments.num_train_epochs):
                     time_s = time.time()
-                    for batch in self.dataloader_train:
+                    for _ in range(self.max_training_steps // self.arguments.num_train_epochs):
+                        batch = next(train_iter)
                         current_step += 1
                         if (
                                 self.arguments.step_start_point is not None
@@ -637,7 +639,9 @@ class CausalLanguageModelTrainer(BaseTrainer):
             accuracy_sum = None
 
             try:
-                for batch in self.dataloader_eval:
+                eval_iter = iter(self.dataloader_eval)
+                for _ in range(self.max_evaluation_steps):
+                    batch = next(eval_iter)
                     current_step += 1
                     time_start = time.time()
                     for key in self.arguments.ids_to_pop_from_dataset:

--- a/lib/python/EasyDel/trainer/training_configurations.py
+++ b/lib/python/EasyDel/trainer/training_configurations.py
@@ -57,6 +57,7 @@ class TrainArguments(
             model_huggingface_repo_id: Optional[str] = None,
             total_batch_size: int = 32,
             max_training_steps: Optional[int] = None,
+            max_evaluation_steps: Optional[int] = None,
             optimizer: AVAILABLE_OPTIMIZERS = EasyDelOptimizers.ADAMW,
             scheduler: AVAILABLE_SCHEDULERS = EasyDelSchedulers.NONE,
             learning_rate: Union[int, float] = 5e-5,
@@ -127,7 +128,8 @@ The __init__ function can accept arguments, just like a normal function.
 :param model_huggingface_repo_id: Optional[str]: Load a pretrained model from the huggingface model hub
 :param model_class: Optional[EasyDelFlaxPretrainedModel]: Pass a model class to the trainer
 :param total_batch_size: int: Set the batch size of the model
-:param max_training_steps: Optional[int]: Set the maximum number of steps to train for
+:param max_training_steps: Optional[int]: Set the maximum total number of training steps across all epochs
+:param max_evaluation_steps: Optional[int]: Set the maximum number of steps to evaluate for
 :param optimizer: AVAILABLE_OPTIMIZERS: Specify the optimizer used to train the model
 :param scheduler: AVAILABLE_SCHEDULERS: Set the learning rate scheduler
 :param learning_rate: Union[int, float] : Set the learning rate for the optimizer
@@ -245,6 +247,7 @@ The __init__ function can accept arguments, just like a normal function.
         self.wandb_entity = wandb_entity
         self.total_batch_size = total_batch_size
         self.max_training_steps = max_training_steps
+        self.max_evaluation_steps = max_evaluation_steps
         self.optimizer = optimizer
         self.scheduler = scheduler
         self.extra_optimizer_kwargs = extra_optimizer_kwargs

--- a/python_test/easy_mistral_clm_trainer_test.py
+++ b/python_test/easy_mistral_clm_trainer_test.py
@@ -8,15 +8,20 @@ from lib.python.EasyDel import (
     CausalLanguageModelTrainer,
     TrainArguments,
     FlaxMistralForCausalLM,
-    MistralConfig
+    MistralConfig,
 )
 from jax import numpy as jnp, random
-from datasets import Dataset
+from datasets import Dataset, IterableDataset
 
 
-def main():
+def main(use_iterable_dataset: bool):
     sequence_length = 128
-    data_row_size = 100
+    NUM_TRAIN_EXAMPLES = 50
+    NUM_EVAL_EXAMPLES = 12
+    TOTAL_BATCH_SIZE = 2
+    NUM_TRAIN_EPOCHS = 3
+    max_training_steps = NUM_TRAIN_EXAMPLES // TOTAL_BATCH_SIZE * NUM_TRAIN_EPOCHS
+    max_evaluation_steps = NUM_EVAL_EXAMPLES // TOTAL_BATCH_SIZE
     config = MistralConfig(
         hidden_size=128,
         num_attention_heads=8,
@@ -30,26 +35,38 @@ def main():
     model = FlaxMistralForCausalLM(config=config, _do_init=True)
     params = model.params
 
-    def data_generator():
-        for i in range(data_row_size):
+    def data_generator(num_rows: int):
+        for i in range(num_rows):
             yield {
-                "attention_mask": jnp.ones(
-                    (1, sequence_length), dtype="i4"
-                ),
+                "attention_mask": jnp.ones((sequence_length,), dtype="i4"),
                 "input_ids": random.randint(
-                    random.PRNGKey(0), (1, sequence_length), 0, 32000, dtype="i4"
-                )
+                    random.PRNGKey(0), (sequence_length,), 0, 32000, dtype="i4"
+                ),
             }
 
-    example_data = Dataset.from_generator(data_generator, )
+    if not use_iterable_dataset:
+        example_train_data = Dataset.from_generator(
+            data_generator, gen_kwargs={"num_rows": NUM_TRAIN_EXAMPLES}
+        )
+        example_eval_data = Dataset.from_generator(
+            data_generator, gen_kwargs={"num_rows": NUM_EVAL_EXAMPLES}
+        )
+    else:
+        example_train_data = IterableDataset.from_generator(
+            data_generator, gen_kwargs={"num_rows": NUM_TRAIN_EXAMPLES}
+        )
+        example_eval_data = IterableDataset.from_generator(
+            data_generator, gen_kwargs={"num_rows": NUM_EVAL_EXAMPLES}
+        )
     dtype = jnp.float32
     trainer = CausalLanguageModelTrainer(
         arguments=TrainArguments(
             model_name="MistralSmoothZlossTest",
-            num_train_epochs=3,
-            total_batch_size=2,
+            num_train_epochs=NUM_TRAIN_EPOCHS,
+            total_batch_size=TOTAL_BATCH_SIZE,
             gradient_accumulation_steps=2,
-            use_wandb=True,
+            max_training_steps=max_training_steps,
+            max_evaluation_steps=max_evaluation_steps,
             model_class=type(model),
             do_shard_fns=False,
             do_train=True,
@@ -59,11 +76,12 @@ def main():
                 "config": model.config,
                 "input_shape": (1, 1),
                 "dtype": dtype,
-                "param_dtype": dtype
+                "param_dtype": dtype,
             },
             dtype=dtype,
             param_dtype=dtype,
-            track_memory=True,
+            track_memory=False,
+            use_wandb=False,
             learning_rate=5e-4,
             label_smoothing_factor=0.1,
             z_loss=0.0001,
@@ -72,12 +90,16 @@ def main():
             save_total_limit=1,
             do_last_save=True,
         ),
-        dataset_train=example_data,
-        dataset_eval=example_data,
+        dataset_train=example_train_data,
+        dataset_eval=example_eval_data,
     )
 
     trainer.train(model_parameters=flax.core.FrozenDict({"params": params}))
 
 
 if __name__ == "__main__":
-    main()
+    print("Running with normal Dataset:")
+    main(use_iterable_dataset=False)
+
+    print("\nRunning with IterableDataset:")
+    main(use_iterable_dataset=True)


### PR DESCRIPTION
Passing a streaming dataset is now possible, with the following differences:

1. Examples must be padded to max sequence length
2. max_training_steps (and optionally max_evaluation_steps) must be set in the TrainArguments

The reason for 1. is that the collate_fn used for the normal (non-streaming) dataset passed is suitable only for batched hf/torch datasets. Since in the iterable case the batching is handled by tf datasets, existing collate_fn's cannot be used.

This commit adapts the train and eval loops to request only the exact amount of batches as expected, to prevent tf core warning Local rendezvous is aborting with status: OUT_OF_RANGE: End of sequence