### PR TITLE
(feat) add attention logits to model output, add attention soft_cap to vanilla attention; (fix) DP sharding of batch, update dtype of memory tracking interval

### DIFF
--- a/easydel/infra/modeling_outputs.py
+++ b/easydel/infra/modeling_outputs.py
@@ -146,6 +146,7 @@ class ModelOutput(tp.OrderedDict):
 class AttentionLayerOutput(ModelOutput):
     attention_output: chex.Array
     attention_weight: chex.Array | None = None
+    attention_logits: chex.Array | None = None
     cache_view: TransformerCacheView | None = None
 
 
@@ -154,6 +155,7 @@ class EncoderLayerOutput(ModelOutput):
     hidden_states: chex.Array
     residual_states: chex.Array | None = None
     attention_weight: chex.Array | None = None
+    attention_logits: chex.Array | None = None
 
 
 @auto_pytree
@@ -162,6 +164,7 @@ class DecoderLayerOutput(ModelOutput):
     residual_states: chex.Array | None = None
     cross_attention: chex.Array | None = None
     attention_weight: chex.Array | None = None
+    attention_logits: chex.Array | None = None
     router_logits: chex.Array | None = None
     gate_loss: chex.Array | None = None
     cache_view: TransformerCacheView | None = None
@@ -191,6 +194,7 @@ class BaseModelOutput(ModelOutput):
     last_hidden_state: chex.Array = None
     hidden_states: tuple[chex.Array] | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     past_key_values: dict[str, chex.Array] | None = None
     loss: chex.Array | None = None
 
@@ -284,6 +288,7 @@ class BaseModelOutputWithPast(ModelOutput):
     past_key_values: dict[str, chex.Array] | None = None
     hidden_states: tuple[chex.Array] | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -316,6 +321,7 @@ class BaseModelOutputWithPooling(ModelOutput):
     pooler_output: chex.Array = None
     hidden_states: tuple[chex.Array] | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -365,7 +371,9 @@ class BaseModelOutputWithPoolingAndCrossAttentions(ModelOutput):
     hidden_states: tuple[chex.Array] | None = None
     past_key_values: TransformerCache | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     cross_attentions: tuple[chex.Array] | None = None
+    cross_attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -412,7 +420,9 @@ class BaseModelOutputWithPastAndCrossAttentions(ModelOutput):
     past_key_values: TransformerCache | None = None
     hidden_states: tuple[chex.Array] | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     cross_attentions: tuple[chex.Array] | None = None
+    cross_attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -471,10 +481,13 @@ class Seq2SeqModelOutput(ModelOutput):
     past_key_values: TransformerCache | None = None
     decoder_hidden_states: tuple[chex.Array] | None = None
     decoder_attentions: tuple[chex.Array] | None = None
+    decoder_attention_logits: tuple[chex.Array] | None = None
     cross_attentions: tuple[chex.Array] | None = None
+    cross_attention_logits: tuple[chex.Array] | None = None
     encoder_last_hidden_state: chex.Array | None = None
     encoder_hidden_states: tuple[chex.Array] | None = None
     encoder_attentions: tuple[chex.Array] | None = None
+    encoder_attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -516,7 +529,9 @@ class CausalLMOutputWithCrossAttentions(ModelOutput):
     past_key_values: TransformerCache | None = None
     hidden_states: tuple[chex.Array] | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     cross_attentions: tuple[chex.Array] | None = None
+    cross_attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -544,6 +559,7 @@ class MaskedLMOutput(ModelOutput):
     logits: chex.Array = None
     hidden_states: tuple[chex.Array] | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     past_key_values: TransformerCache | None = None
     loss: chex.Array | None = None
 
@@ -602,10 +618,13 @@ class Seq2SeqLMOutput(ModelOutput):
     past_key_values: TransformerCache | None = None
     decoder_hidden_states: tuple[chex.Array] | None = None
     decoder_attentions: tuple[chex.Array] | None = None
+    decoder_attention_logits: tuple[chex.Array] | None = None
     cross_attentions: tuple[chex.Array] | None = None
+    cross_attention_logits: tuple[chex.Array] | None = None
     encoder_last_hidden_state: chex.Array | None = None
     encoder_hidden_states: tuple[chex.Array] | None = None
     encoder_attentions: tuple[chex.Array] | None = None
+    encoder_attention_logits: tuple[chex.Array] | None = None
     loss: chex.Array | None = None
 
 
@@ -900,6 +919,7 @@ class MoeModelOutput(ModelOutput):
     hidden_states: tuple[chex.Array] | None = None
     past_key_values: TransformerCache | None = None
     attentions: tuple[chex.Array] | None = None
+    attention_logits: tuple[chex.Array] | None = None
     router_logits: tuple[chex.Array] | None = None
     all_router_losses: tuple[chex.Array] | None = None
     logits: chex.Array = None

--- a/easydel/layers/attention.py
+++ b/easydel/layers/attention.py
@@ -181,6 +181,7 @@ class FlexibleAttentionModule(nn.Module):
         base_config: EasyDeLBaseConfig,
         softmax_scale: float,
         dropout_prob: float = 0.0,
+        soft_cap: float | None = None,
         *,
         rngs: nn.Rngs | None = None,
     ):
@@ -193,6 +194,8 @@ class FlexibleAttentionModule(nn.Module):
             softmax_scale (float): The scaling factor to apply before the softmax function.
             dropout_prob (float, optional): The dropout probability for attention weights.
                                              Defaults to 0.0.
+            soft_cap (float | None, optional): Optional soft cap for attention weights.
+                                               Defaults to None.
         """
         if rngs is None:
             rngs = nn.Rngs(42)
@@ -210,6 +213,7 @@ class FlexibleAttentionModule(nn.Module):
             config=base_config,
             softmax_scale=softmax_scale,
             dropout_prob=dropout_prob,
+            soft_cap=soft_cap,
         )
         self.config = base_config
         self.metadata = metadata

--- a/easydel/layers/attention_operator/_attention_impl.py
+++ b/easydel/layers/attention_operator/_attention_impl.py
@@ -171,7 +171,7 @@ class AttentionMetadata:
         config: EasyDeLBaseConfig,
         softmax_scale: float,
         dropout_prob: float = 0.0,
-        soft_cap: int | None = None,
+        soft_cap: float | None = None,
     ) -> AttentionMetadata:
         """
         Factory method to create AttentionMetadata from an EasyDeLBaseConfig.

--- a/easydel/layers/attention_operator/_attention_impl.py
+++ b/easydel/layers/attention_operator/_attention_impl.py
@@ -62,6 +62,7 @@ class AttentionOutput:
     """
 
     attention_weights: Array | None = None
+    attention_logits: Array | None = None
     attention_outputs: Array | None = None
 
 

--- a/easydel/layers/attention_operator/modules/vanilla.py
+++ b/easydel/layers/attention_operator/modules/vanilla.py
@@ -132,6 +132,10 @@ class VanillaAttn(AttentionImpl):
 
             aw = jnp.einsum("bskhd,bmkd->bkhsm", q * sm_scale, k, optimize=True)
 
+        soft_cap = self.metadata.soft_cap
+        if soft_cap is not None:
+            aw = soft_cap * jnp.tanh(aw / soft_cap)
+
         if bias is not None:
             if bias.shape[1] == (kh * num_reps):
                 bias = bias.reshape(b, kh, num_reps, qs, ks)

--- a/easydel/trainers/base_trainer.py
+++ b/easydel/trainers/base_trainer.py
@@ -327,7 +327,11 @@ class BaseTrainer(BaseTrainerProtocol):
         if not self.arguments.performance_mode:
             import easydel
 
-            interval = 1.0 if self.arguments.track_memory is True else self.arguments.track_memory
+            interval = (
+                self.arguments.track_memory
+                if isinstance(self.arguments.track_memory, (int, float))
+                else 1.0
+            )
             self.memory_monitor = easydel.utils.analyze_memory.SMPMemoryMonitor(interval)
 
     def __repr__(self):

--- a/easydel/trainers/direct_preference_optimization_trainer/_fn.py
+++ b/easydel/trainers/direct_preference_optimization_trainer/_fn.py
@@ -792,7 +792,7 @@ def training_step(
         batch_partition_spec=partition_spec,
     )
 
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
     _loss_func = get_loss_function(
         loss_type=loss_type,
         beta=beta,
@@ -905,7 +905,7 @@ def evaluation_step(
         batch_partition_spec=partition_spec,
     )
 
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
     _loss_func = get_loss_function(
         loss_type=loss_type,
         beta=beta,

--- a/easydel/trainers/distillation_trainer/_fn.py
+++ b/easydel/trainers/distillation_trainer/_fn.py
@@ -84,7 +84,7 @@ def distillation_step(
         gradient_accumulation_steps=gradient_accumulation_steps,
         batch_partition_spec=partition_spec,
     )
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def loss_fn(tree, minibatch):
         module = flax.nnx.merge(student_state.graphdef, tree, student_state.graphother)

--- a/easydel/trainers/group_relative_policy_optimization/_fn.py
+++ b/easydel/trainers/group_relative_policy_optimization/_fn.py
@@ -87,7 +87,7 @@ def grpo_step(
         gradient_accumulation_steps=gradient_accumulation_steps,
         batch_partition_spec=partition_spec,
     )
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def loss_fn(tree, minibatch):
         module = flax.nnx.merge(state.graphdef, tree, state.graphother)

--- a/easydel/trainers/odds_ratio_preference_optimization_trainer/_fn.py
+++ b/easydel/trainers/odds_ratio_preference_optimization_trainer/_fn.py
@@ -328,7 +328,7 @@ def orpo_step(
     )
 
     # Apply sharding constraints to the batch.
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def calculate_loss(tree: nn.GraphState, batch: dict):
         """

--- a/easydel/trainers/reward_trainer/_fn.py
+++ b/easydel/trainers/reward_trainer/_fn.py
@@ -73,7 +73,7 @@ def training_step(
         gradient_accumulation_steps=gradient_accumulation_steps,
         batch_partition_spec=partition_spec,
     )
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def loss_fn(tree, minibatch):
         """
@@ -176,7 +176,7 @@ def evaluation_step(
         gradient_accumulation_steps=1,
         batch_partition_spec=partition_spec,
     )
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def loss_fn(tree):
         """

--- a/easydel/trainers/trainer/_fn.py
+++ b/easydel/trainers/trainer/_fn.py
@@ -70,7 +70,7 @@ def training_step(
         gradient_accumulation_steps=gradient_accumulation_steps,
         batch_partition_spec=partition_spec,
     )
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def loss_fn(tree, minibatch):
         """
@@ -157,7 +157,7 @@ def evaluation_step(
         gradient_accumulation_steps=1,
         batch_partition_spec=partition_spec,
     )
-    batch = with_sharding_constraint(arr=batch, sharding=partition_spec)
+    batch = with_sharding_constraint(arr=batch, sharding={key: partition_spec for key in batch.keys()})
 
     def loss_fn(tree):
         """

--- a/easydel/utils/analyze_memory.py
+++ b/easydel/utils/analyze_memory.py
@@ -38,7 +38,7 @@ except ImportError:
 
 
 class SMPMemoryMonitor:
-    def __init__(self, check_interval: int = 60, quiet: bool = False):
+    def __init__(self, check_interval: float = 60.0, quiet: bool = False):
         """
         Initialize the memory monitor.
 


### PR DESCRIPTION
Collection of various improvements:
- Attention logits in model output: useful for experiment tracking and debugging
- Attention softcap: used by Gemma, now also supported by vanilla attention
- DP sharding of batch: now correctly shards the batch along the DP axis. Depends on a breaking change in `eformer` (https://github.com/erfanzar/eformer/pull/4).
- Minor change to check_interval dtype for memory tracking.