### PR TITLE
Default finish_reason to "stop" instead of unsupported "finished"

### DIFF
--- a/easydel/inference/esurge/esurge_engine.py
+++ b/easydel/inference/esurge/esurge_engine.py
@@ -1362,7 +1362,7 @@ class eSurge:
                         comp = ro.outputs[0]
                         ro.finished = True
                         comp.finish_reason = (
-                            str(engine_output.finish_reason) if engine_output.finish_reason else "finished"
+                            str(engine_output.finish_reason) if engine_output.finish_reason else "stop"
                         )
 
                         num_generated = len(rd["generated_tokens"])

--- a/easydel/inference/esurge/server/api_server.py
+++ b/easydel/inference/esurge/server/api_server.py
@@ -507,8 +507,6 @@ class eSurgeApiServer(BaseInferenceApiServer, ToolCallingMixin):
                 finish_reason = completion.finish_reason
             else:
                 finish_reason = finish_reason_extracted
-            if finish_reason == "finished":
-                finish_reason = "stop"
             choices.append(ChatCompletionResponseChoice(index=idx, message=message, finish_reason=finish_reason))
 
         usage = UsageInfo(


### PR DESCRIPTION
This PR changes `finish_reason` in esurge to default to "stop". Otherwise, /v1/completion requests throw a pydantic Exception since the current default "finished" is not a valid option: https://github.com/erfanzar/EasyDeL/blob/b43a6b3cb7437d03bf94930822064deec1cf47d6/easydel/inference/openai_api_modules.py#L296