### PR TITLE
fix: implement tool parser cloning for isolated request handling

### DIFF
--- a/easydel/inference/esurge/server/api_server.py
+++ b/easydel/inference/esurge/server/api_server.py
@@ -615,7 +615,7 @@ class eSurgeApiServer(BaseInferenceApiServer, ToolCallingMixin):
             prompt_tokens = len(esurge.tokenizer(content)["input_ids"])
             sampling_params = self._create_sampling_params(request)
 
-            tool_parser = self.get_tool_parser_for_model(request.model)
+            tool_parser = self.clone_tool_parser_for_model(request.model)
 
             previous_text = ""
             previous_token_ids = []
@@ -646,6 +646,7 @@ class eSurgeApiServer(BaseInferenceApiServer, ToolCallingMixin):
                             current_token_ids=current_token_ids,
                             delta_token_ids=delta_token_ids,
                             request=request,
+                            parser=tool_parser,
                         )
                         previous_text = current_text
                         previous_token_ids = current_token_ids

--- a/easydel/inference/vsurge/server/api_server.py
+++ b/easydel/inference/vsurge/server/api_server.py
@@ -353,7 +353,7 @@ class vSurgeApiServer(BaseInferenceApiServer, ToolCallingMixin):
             prompt_tokens = vsurge.count_tokens(content)
             sampling_params = self._create_sampling_params(request)
 
-            tool_parser = self.get_tool_parser_for_model(request.model)
+            tool_parser = self.clone_tool_parser_for_model(request.model)
 
             previous_text = ""
 
@@ -400,6 +400,7 @@ class vSurgeApiServer(BaseInferenceApiServer, ToolCallingMixin):
                                 current_text=current_text,
                                 delta_text=delta_text,
                                 request=request,
+                                parser=tool_parser,
                             )
 
                             previous_text = current_text


### PR DESCRIPTION
This pull request introduces improvements to how tool parsers are managed and used during streaming inference in both the `esurge` and `vsurge` servers. The main goal is to ensure that each request operates with an isolated instance of the tool parser, preventing potential state leakage between requests and enhancing thread safety.