### PR TITLE
feat: Add unified attention mechanism and related caching structures

### DIFF
--- a/easydel/inference/esurge/runners/execution_protocol.py
+++ b/easydel/inference/esurge/runners/execution_protocol.py
@@ -28,7 +28,12 @@ from typing import Protocol, runtime_checkable
 import jax
 import numpy as np
 
-from easydel.layers.caching import RaggedPagesCache, RaggedPagesCacheView
+from easydel.layers.caching import (
+    RaggedPagesCache,
+    RaggedPagesCacheConfig,
+    UnifiedAttentionCache,
+    UnifiedAttentionCacheConfig,
+)
 
 from .execution_types import BatchMetadata, ModelStepOutputs, StepFunctionInputs
 
@@ -48,12 +53,12 @@ class ExecutionManagerProtocol(Protocol):
 
     model: "EasyDeLBaseModule"
     mesh: tp.Any
-    kv_pages: RaggedPagesCache
+    kv_pages: RaggedPagesCache | UnifiedAttentionCache
     rng_key: jax.Array
     max_model_len: int
     max_num_reqs: int
     max_num_tokens: int
-    metadata: RaggedPagesCacheView
+    metadata: RaggedPagesCacheConfig | UnifiedAttentionCacheConfig
 
     def clear_cache(self) -> None: ...
 
@@ -72,7 +77,7 @@ class ExecutionManagerProtocol(Protocol):
         num_reqs_max_model_len: int,
         max_pages_per_req: int,
         max_num_reqs: int,
-        metadata: RaggedPagesCacheView,
+        metadata: RaggedPagesCacheConfig | UnifiedAttentionCacheConfig,
         num_reqs_paddings: list[int] | None = None,
     ) -> None: ...
 

--- a/easydel/inference/esurge/scheduler/scheduler.py
+++ b/easydel/inference/esurge/scheduler/scheduler.py
@@ -146,8 +146,12 @@ class Scheduler(SchedulerInterface):
             config=model_config,
             page_size=metadata.page_size,
             num_kv_heads=metadata.num_kv_heads,
-            head_size=metadata.k_headdim,
-            dtype=runner.executor_manager.kv_pages.views[-1].kv_pages.dtype,
+            head_size=getattr(metadata, "k_headdim", None) or getattr(metadata, "head_dim", None),
+            dtype=(
+                runner.executor_manager.kv_pages.views[-1].kv_pages.dtype
+                if hasattr(runner.executor_manager.kv_pages.views[-1], "kv_pages")
+                else runner.executor_manager.kv_pages.views[-1].key_cache.dtype
+            ),
             use_mla=False,
         )
 

--- a/easydel/infra/elarge_model/elarge_model.py
+++ b/easydel/infra/elarge_model/elarge_model.py
@@ -510,6 +510,7 @@ class eLargeModel:
                 - "blocksparse": Block sparse attention
                 - "ragged_page_attention_v2": Ragged page attention v2
                 - "ragged_page_attention_v3": Ragged page attention v3
+                - "unified_attention": Unified paged attention (vLLM-style)
                 - "sdpa": Scaled dot product attention
                 - "vanilla": Vanilla attention
             **kwargs: Individual operation configs as keyword arguments.

--- a/easydel/infra/elarge_model/types.py
+++ b/easydel/infra/elarge_model/types.py
@@ -65,6 +65,7 @@ OperationImplName = tp.Literal[
     "blocksparse",
     "ragged_page_attention_v2",
     "ragged_page_attention_v3",
+    "unified_attention",
     "sdpa",
     "cudnn",
     "cuda_flash_attn2",
@@ -87,6 +88,7 @@ class OperationConfigsDict(TypedDict, total=False):
         blocksparse: Config for block sparse attention.
         ragged_page_attention_v2: Config for ragged page attention v2.
         ragged_page_attention_v3: Config for ragged page attention v3.
+        unified_attention: Config for unified attention (vLLM-style paged attention).
         sdpa: Config for scaled dot product attention (also registered as cudnn, cuda_flash_attn2).
         vanilla: Config for vanilla attention.
 
@@ -103,6 +105,7 @@ class OperationConfigsDict(TypedDict, total=False):
     blocksparse: NotRequired["BaseOperationConfig | None"]
     ragged_page_attention_v2: NotRequired["BaseOperationConfig | None"]
     ragged_page_attention_v3: NotRequired["BaseOperationConfig | None"]
+    unified_attention: NotRequired["BaseOperationConfig | None"]
     sdpa: NotRequired["BaseOperationConfig | None"]
     vanilla: NotRequired["BaseOperationConfig | None"]
 

--- a/easydel/infra/etils.py
+++ b/easydel/infra/etils.py
@@ -196,6 +196,7 @@ AVAILABLE_ATTENTION_MECHANISMS = tp.Literal[
     "ragged_page_attention_v2",
     "ragged_page_attention_v3",
     "page_attention",
+    "unified_attention",
 ]
 
 DEFAULT_ATTENTION_MECHANISM = "vanilla"

--- a/easydel/layers/attention_unified.py
+++ b/easydel/layers/attention_unified.py
@@ -51,6 +51,7 @@ from .caching import (
     RaggedPagesMetadata,
     TransformerCacheView,
     TransformerMetadata,
+    UnifiedAttentionCacheView,
 )
 from .linear import ColumnParallelLinear, RowParallelLinear
 from .norms import RMSNorm
@@ -750,7 +751,7 @@ class UnifiedAttention(AttentionModule, Generic[Cfg]):
         mask_info: MaskInfo | None,
         position_ids: Int[Array, "batch seq_len"],
         mode: common_types.RUNTIME_MODE_TYPES,  # type:ignore
-        cache_view: TransformerCacheView | RaggedPagesCacheView | None = None,
+        cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None,
         cache_metadata: TransformerMetadata | RaggedPagesMetadata | OperationsMetadata | None = None,
         output_attentions: bool = False,
         frequencies: Float[Array, "seq_len head_dim"] | None = None,
@@ -896,7 +897,7 @@ class UnifiedAttention(AttentionModule, Generic[Cfg]):
         mask_info: MaskInfo | None,
         position_ids: Int[Array, "batch seq_len"],
         mode: common_types.RUNTIME_MODE_TYPES,  # type:ignore
-        cache_view: TransformerCacheView | RaggedPagesCacheView | None = None,
+        cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None,
         cache_metadata: TransformerMetadata | RaggedPagesMetadata | OperationsMetadata | None = None,
         output_attentions: bool = False,
         frequencies: Float[Array, "seq_len head_dim"] | None = None,
@@ -1037,7 +1038,7 @@ class UnifiedAttention(AttentionModule, Generic[Cfg]):
         mask_info: MaskInfo | None,
         position_ids: Int[Array, "batch seq_len"],
         mode: common_types.RUNTIME_MODE_TYPES,  # type:ignore
-        cache_view: TransformerCacheView | RaggedPagesCacheView | None = None,
+        cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None,
         cache_metadata: TransformerMetadata | RaggedPagesMetadata | OperationsMetadata | None = None,
         output_attentions: bool = False,
         alibi: Float[Array, "batch_or_1 heads qseq_len_or_1 kvseq_len_or_1"] | None = None,
@@ -1124,7 +1125,7 @@ class UnifiedAttention(AttentionModule, Generic[Cfg]):
         mask_info: MaskInfo | None,
         position_ids: Int[Array, "batch seq_len"],
         mode: common_types.RUNTIME_MODE_TYPES,  # type:ignore
-        cache_view: TransformerCacheView | RaggedPagesCacheView | None = None,
+        cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None,
         cache_metadata: TransformerMetadata | RaggedPagesMetadata | OperationsMetadata | None = None,
         output_attentions: bool = False,
         frequencies: Float[Array, "seq_len head_dim"] | None = None,

--- a/easydel/layers/caching/__init__.py
+++ b/easydel/layers/caching/__init__.py
@@ -96,6 +96,7 @@ from .recurrent import (
     RecurrentMetadata,
 )
 from .transformer import TransformerCache, TransformerCacheConfig, TransformerCacheView, TransformerMetadata
+from .unified_attention import UnifiedAttentionCache, UnifiedAttentionCacheConfig, UnifiedAttentionCacheView
 
 __all__ = (
     "AttentionMetadataBuilder",
@@ -134,5 +135,8 @@ __all__ = (
     "TransformerCacheConfig",
     "TransformerCacheView",
     "TransformerMetadata",
+    "UnifiedAttentionCache",
+    "UnifiedAttentionCacheConfig",
+    "UnifiedAttentionCacheView",
     "unwrap_metadata",
 )

--- a/easydel/layers/caching/_metadatabuilder.py
+++ b/easydel/layers/caching/_metadatabuilder.py
@@ -122,6 +122,7 @@ class AttentionMetadataBuilder:
         "ragged_page_attention_v3",
         "page_attention",
         "paged_attention",
+        "unified_attention",
     }
 
     @classmethod

--- a/easydel/layers/caching/unified_attention/__init__.py
+++ b/easydel/layers/caching/unified_attention/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2025 The EasyDeL Author @erfanzar (Erfan Zare Chavoshi).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .cache import UnifiedAttentionCache, UnifiedAttentionCacheConfig, UnifiedAttentionCacheView
+
+__all__ = (
+    "UnifiedAttentionCache",
+    "UnifiedAttentionCacheConfig",
+    "UnifiedAttentionCacheView",
+)
+

--- a/easydel/layers/caching/unified_attention/cache.py
+++ b/easydel/layers/caching/unified_attention/cache.py
@@ -1,0 +1,332 @@
+# Copyright 2025 The EasyDeL Author @erfanzar (Erfan Zare Chavoshi).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import typing as tp
+
+import jax
+import jax.numpy as jnp
+from eformer import common_types
+from eformer import escale as es
+from eformer.escale import PartitionAxis, PartitionManager
+from eformer.loggings import get_logger
+from eformer.mpric import DTYPE_TO_STRING_MAP
+from eformer.pytree import auto_pytree, field
+from jax.sharding import Mesh
+from jax.sharding import NamedSharding as Ns
+from jaxtyping import Array, Float
+
+from easydel.layers.caching.ragged_page.utils import kv_cache_update_jax
+
+from .._abstracts import BaseCache, BaseCacheConfig, BaseCacheView, unwrap_metadata
+
+if tp.TYPE_CHECKING:
+    from easydel.layers.quantization.quantizers import EasyQuantizer
+else:
+    EasyQuantizer = object
+
+logger = get_logger(__name__)
+
+EMPTY = common_types.EMPTY
+KV_HEAD = common_types.KV_HEAD
+MODE_PREFILL = common_types.MODE_PREFILL
+
+
+def cdiv(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def per_device_hbm_budget_bytes(util: float = 0.9, mode: str = "free", safety_margin: int = 256 << 20) -> int:
+    budgets: list[int] = []
+    for device in jax.local_devices():
+        try:
+            stats = device.memory_stats()
+        except Exception:
+            continue
+        limit = stats.get("bytes_limit") or stats.get("bytes_reservable_limit") or stats.get("bytes_total")
+        used_in_use = stats.get("bytes_in_use", 0)
+        used_reserved = stats.get("bytes_reserved", 0)
+        used = max(used_in_use, used_reserved)
+        if limit is None:
+            continue
+
+        free = max(0, int(limit) - int(used))
+        if mode == "free":
+            usable = max(0, int(free * float(util)) - safety_margin)
+        else:
+            usable = max(0, int(int(limit) * float(util)) - int(used) - safety_margin)
+        budgets.append(usable)
+
+    return min(budgets) if budgets else 4 * (1024**3)
+
+
+def _previous_power_of_2(n: int) -> int:
+    if n <= 0:
+        return 1
+    return 1 << (n.bit_length() - 1)
+
+
+@auto_pytree
+class UnifiedAttentionCacheConfig(BaseCacheConfig):
+    """Paged KV-cache config for vLLM-style unified attention.
+
+    Storage layout:
+        - key_cache/value_cache per layer: [num_blocks, block_size, num_kv_heads, head_dim]
+
+    This matches ejkernel's Triton UnifiedAttention kernel input contract.
+    """
+
+    num_hidden_layers: int = field(pytree_node=False)
+    max_model_length: int = field(pytree_node=False)
+    num_kv_heads: int = field(pytree_node=False)
+    head_dim: int = field(pytree_node=False)
+
+    hbm_utilization: float = field(pytree_node=False, default=0.9)
+    page_size: int = field(pytree_node=False, default=128)
+    num_pages: int = field(pytree_node=False, default=-1)
+    max_num_pages_per_req: int = field(pytree_node=False, default=-1)
+
+    # Used by eSurge's slot-mapping padding logic (v2-style cache updates).
+    num_slices_per_kv_cache_update_page: int = field(pytree_node=False, default=-1)
+
+    # Exposed to keep eSurge metadata builder compatible.
+    version: tp.Literal["v2"] = field(pytree_node=False, default="v2")
+
+    _kvdtype_str: str = field(pytree_node=False, default="bf16")
+
+    @staticmethod
+    def _compute_free_hbm(mesh: Mesh, partition_manager: PartitionManager, hbm_utilization: float) -> int:
+        kv_head_axis = partition_manager.paxis.kv_head_axis
+        size = int(mesh.shape[kv_head_axis])
+        budget = per_device_hbm_budget_bytes(hbm_utilization, mode="free")
+        available_alloc = budget * size
+        logger.info(f"{kv_head_axis=} {size=} {budget=} {available_alloc=} {hbm_utilization=}")
+        return available_alloc
+
+    @classmethod
+    def create(
+        cls,
+        mesh: Mesh,
+        partition_manager: PartitionManager,
+        kvdtype: jnp.dtype,
+        num_hidden_layers: int,
+        num_kv_heads: int,
+        max_model_length: int,
+        head_dim: int,
+        *,
+        hbm_utilization: float = 0.9,
+        page_size: int = 128,
+    ) -> "UnifiedAttentionCacheConfig":
+        if num_hidden_layers <= 0:
+            raise ValueError("`num_hidden_layers` must be positive")
+        if num_kv_heads <= 0:
+            raise ValueError("`num_kv_heads` must be positive")
+        if head_dim <= 0:
+            raise ValueError("`head_dim` must be positive")
+        if page_size <= 0:
+            raise ValueError("`page_size` must be positive")
+        if max_model_length <= 0:
+            raise ValueError("`max_model_length` must be positive")
+
+        free = cls._compute_free_hbm(mesh=mesh, partition_manager=partition_manager, hbm_utilization=hbm_utilization)
+        bytes_av = jnp.finfo(kvdtype).bits // 8
+        # Two tensors (K+V) per layer.
+        page_bytes = 2 * num_hidden_layers * page_size * num_kv_heads * head_dim * bytes_av
+        num_pages = int(free) // int(page_bytes)
+        logger.info(
+            f"Creating UnifiedAttentionCacheConfig with {num_pages=} {page_bytes=} "
+            f"sequence_capacity={int((num_pages * page_size) / 1000)}K"
+        )
+
+        # A lightweight heuristic for slot-mapping padding; matches eSurge expectations.
+        page_size_bytes = 2 * page_size * num_kv_heads * head_dim * bytes_av
+        # Keep this conservative; it only affects padding of the update schedule.
+        slices_raw = (16 * 1024 * 1024) // max(1, int(page_size_bytes))
+        num_slices_per_page = min(64, _previous_power_of_2(int(slices_raw)))
+
+        return cls(
+            num_hidden_layers=num_hidden_layers,
+            max_model_length=max_model_length,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            hbm_utilization=hbm_utilization,
+            page_size=page_size,
+            num_pages=num_pages,
+            max_num_pages_per_req=cdiv(max_model_length, page_size),
+            num_slices_per_kv_cache_update_page=int(num_slices_per_page),
+            _kvdtype_str=DTYPE_TO_STRING_MAP[kvdtype],
+        )
+
+    @property
+    def kvdtype(self) -> jnp.dtype:
+        from eformer.mpric import STRING_TO_DTYPE_MAP
+
+        return STRING_TO_DTYPE_MAP[self._kvdtype_str]
+
+    def get_padded_num_slices(
+        self,
+        num_tokens: int | None = None,
+        max_num_reqs: int | None = None,
+    ) -> int:
+        if num_tokens is None or num_tokens <= 0:
+            num_tokens = self.max_model_length
+        if max_num_reqs is None or max_num_reqs <= 0:
+            max_num_reqs = self.get_max_num_seqs()
+
+        padded_num_slices = 2 * int(max_num_reqs) + int(num_tokens) // int(self.page_size)
+        padded_num_slices = min(int(padded_num_slices), int(num_tokens))
+
+        slices_per_page = max(1, int(self.num_slices_per_kv_cache_update_page))
+        padded_num_slices = ((padded_num_slices + slices_per_page - 1) // slices_per_page) * slices_per_page
+        return int(padded_num_slices)
+
+    def get_max_num_seqs(self) -> int:
+        # Same heuristic as RaggedPagesCacheConfig.
+        num_page_per_req = cdiv(self.max_model_length, self.page_size)
+        return 1024 * 1024 // 2 // num_page_per_req // 4
+
+
+@auto_pytree
+class UnifiedAttentionCacheView(BaseCacheView):
+    """Per-layer KV-cache view for unified attention."""
+
+    metadata: UnifiedAttentionCacheConfig
+    layer_index: int = field(pytree_node=False)
+
+    key_cache: Float[Array, "num_pages page_size num_kv_heads head_dim"]
+    value_cache: Float[Array, "num_pages page_size num_kv_heads head_dim"]
+
+    partition_manager: PartitionManager = field(
+        pytree_node=False,
+        default_factory=lambda: PartitionManager(PartitionAxis()),
+    )
+
+    @classmethod
+    def init(
+        cls,
+        config: UnifiedAttentionCacheConfig,
+        layer_index: int | None = None,
+        *,
+        mesh: Mesh | None = None,
+        partition_manager: es.PartitionManager | None = None,
+        quantizer: EasyQuantizer | None = None,
+    ) -> "UnifiedAttentionCacheView":
+        if partition_manager is None:
+            partition_manager = PartitionManager(PartitionAxis())
+
+        key_shape = (config.num_pages, config.page_size, config.num_kv_heads, config.head_dim)
+        axes = [EMPTY, EMPTY, KV_HEAD, EMPTY]
+        sharding_spec = partition_manager.resolve(axes=axes, mode=MODE_PREFILL, shape=key_shape)
+        sharding = Ns(mesh=mesh, spec=sharding_spec)
+
+        with jax.named_scope("easydel-unified-attention-cache-init"):
+            key_cache = jnp.zeros(shape=key_shape, dtype=config.kvdtype, device=sharding)
+            value_cache = jnp.zeros(shape=key_shape, dtype=config.kvdtype, device=sharding)
+
+        if quantizer is not None and callable(quantizer):
+            key_cache = quantizer(key_cache)
+            value_cache = quantizer(value_cache)
+
+        return cls(
+            metadata=config,
+            layer_index=layer_index or 0,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            partition_manager=partition_manager,
+        )
+
+    def concatenate_to_cache(
+        self,
+        key: Float[Array, "batch seq_len num_kv_heads head_dim"],
+        value: Float[Array, "batch seq_len num_kv_heads head_dim"],
+        cache_metadata: tp.Any,
+    ) -> "UnifiedAttentionCacheView":
+        cache_metadata = unwrap_metadata(cache_metadata, "ragged")
+
+        if cache_metadata.slot_mapping is None or cache_metadata.num_kv_update_slices is None:
+            raise ValueError("UnifiedAttentionCacheView requires v2-style `slot_mapping` and `num_kv_update_slices`.")
+
+        # Flatten to `[total_tokens, num_kv_heads, head_dim]`.
+        key_tokens = key.reshape(-1, *key.shape[-2:]).astype(self.key_cache.dtype)
+        value_tokens = value.reshape(-1, *value.shape[-2:]).astype(self.value_cache.dtype)
+
+        pages_k = self.key_cache.reshape(-1, *self.key_cache.shape[-2:])
+        pages_v = self.value_cache.reshape(-1, *self.value_cache.shape[-2:])
+
+        pages_k = kv_cache_update_jax(
+            key_tokens,
+            cache_metadata.slot_mapping,
+            pages_k,
+            cache_metadata.num_kv_update_slices,
+            page_size=int(cache_metadata.page_size),
+        )
+        pages_v = kv_cache_update_jax(
+            value_tokens,
+            cache_metadata.slot_mapping,
+            pages_v,
+            cache_metadata.num_kv_update_slices,
+            page_size=int(cache_metadata.page_size),
+        )
+
+        new_key_cache = pages_k.reshape(self.key_cache.shape)
+        new_value_cache = pages_v.reshape(self.value_cache.shape)
+        return self.replace(key_cache=new_key_cache, value_cache=new_value_cache)
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}(layer_index={self.layer_index}, "
+            f"key_cache_shape={getattr(self.key_cache, 'shape', None)}, "
+            f"value_cache_shape={getattr(self.value_cache, 'shape', None)})"
+        )
+
+    __str__ = __repr__
+
+
+@auto_pytree
+class UnifiedAttentionCache(BaseCache):
+    """Cache container holding per-layer unified attention cache views."""
+
+    views: list[UnifiedAttentionCacheView]
+
+    @property
+    def metadata(self) -> UnifiedAttentionCacheConfig | None:
+        if not self.views or self.views[-1] is None:
+            return None
+        return self.views[-1].metadata
+
+    @classmethod
+    def init_cache(
+        cls,
+        *,
+        mesh: Mesh,
+        config: UnifiedAttentionCacheConfig,
+        partition_manager: es.PartitionManager,
+        quantizer: EasyQuantizer | None = None,
+    ) -> "UnifiedAttentionCache":
+        views = [
+            UnifiedAttentionCacheView.init(
+                config=config,
+                layer_index=i,
+                mesh=mesh,
+                partition_manager=partition_manager,
+                quantizer=quantizer,
+            )
+            for i in range(config.num_hidden_layers)
+        ]
+        return cls(views=views)
+
+    @classmethod
+    def init_empty(cls, num_hidden_layers: int, *args, **kwargs) -> "UnifiedAttentionCache":
+        return cls(views=[None] * int(num_hidden_layers))

--- a/easydel/layers/decoder_base.py
+++ b/easydel/layers/decoder_base.py
@@ -54,6 +54,7 @@ from .caching import (
     RaggedPagesMetadata,
     TransformerCacheView,
     TransformerMetadata,
+    UnifiedAttentionCacheView,
 )
 
 
@@ -78,7 +79,7 @@ class BaseDecoderLayer:
         mask_info: MaskInfo | None,
         position_ids: Int[Array, "batch seq_len"],
         mode: common_types.RUNTIME_MODE_TYPES,  # type:ignore
-        cache_view: TransformerCacheView | RaggedPagesCacheView | None = None,
+        cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None,
         cache_metadata: TransformerMetadata | RaggedPagesMetadata | OperationsMetadata | None = None,
         output_attentions: bool = False,
         frequencies: Float[Array, "seq_len head_dim"] | None = None,
@@ -207,7 +208,7 @@ class BaseDecoderLayer:
         position_ids: Int[Array, "batch seq_len"],
         mode: common_types.RUNTIME_MODE_TYPES,  # type:ignore
         partition_manager,
-        cache_view: TransformerCacheView | RaggedPagesCacheView | None = None,
+        cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None,
         cache_metadata: TransformerMetadata | RaggedPagesMetadata | OperationsMetadata | None = None,
         output_attentions: bool = False,
         frequencies: Float[Array, "seq_len head_dim"] | None = None,

--- a/easydel/layers/operations/__init__.py
+++ b/easydel/layers/operations/__init__.py
@@ -56,6 +56,7 @@ from ejkernel.modules.operations.configs import (
     RaggedPageAttentionv3Config,
     RingAttentionConfig,
     ScaledDotProductAttentionConfig,
+    UnifiedAttentionConfig,
 )
 
 from ._attention_outputs import AttentionOutput
@@ -116,6 +117,7 @@ __all__ = (
     "RingAttn",
     "ScaledDotProductAttentionConfig",
     "ScaledDotProductAttn",
+    "UnifiedAttentionConfig",
     "ValidationResult",
     "VanillaAttn",
 )

--- a/easydel/layers/operations/_attention_outputs.py
+++ b/easydel/layers/operations/_attention_outputs.py
@@ -4,7 +4,7 @@ from eformer.pytree import auto_pytree
 from jax import Array
 from jaxtyping import Float
 
-from ..caching import RaggedPagesCacheView, TransformerCacheView
+from ..caching import RaggedPagesCacheView, TransformerCacheView, UnifiedAttentionCacheView
 from ._operation_impl import OperationOutput
 
 
@@ -16,4 +16,4 @@ class AttentionOutput(OperationOutput):
 
     attention_weights: Float[Array, "batch num_heads seq_len seq_len"] | None = None
     attention_outputs: Float[Array, "batch seq_len num_heads head_dim"] | None = None
-    cache_view: TransformerCacheView | RaggedPagesCacheView | None = None
+    cache_view: TransformerCacheView | RaggedPagesCacheView | UnifiedAttentionCacheView | None = None

--- a/easydel/layers/operations/_operation_meta.py
+++ b/easydel/layers/operations/_operation_meta.py
@@ -334,6 +334,7 @@ class OperationMetadata:
                 - "blocksparse": Block sparse attention
                 - "ragged_page_attention_v2": Ragged page attention v2
                 - "ragged_page_attention_v3": Ragged page attention v3
+                - "unified_attention": Unified paged attention (vLLM-style)
                 - "sdpa": Scaled dot product attention
                 - "vanilla": Vanilla attention
 

--- a/easydel/layers/operations/modules/__init__.py
+++ b/easydel/layers/operations/modules/__init__.py
@@ -22,6 +22,7 @@ from .ring_attention import RingAttn
 from .scaled_dot_product_attention import ScaledDotProductAttn
 from .ssm1 import SSM1Op, SSM1Output
 from .ssm2 import SSM2Op, SSM2Output
+from .unified_attention import UnifiedAttn
 from .vanilla_attention import VanillaAttn
 
 __all__ = (
@@ -40,6 +41,7 @@ __all__ = (
     "SSM2Op",
     "SSM2Output",
     "ScaledDotProductAttn",
+    "UnifiedAttn",
     "VanillaAttn",
     "fused_kda_gate",
 )

--- a/easydel/layers/operations/modules/unified_attention.py
+++ b/easydel/layers/operations/modules/unified_attention.py
@@ -1,0 +1,117 @@
+# Copyright 2025 The EasyDeL Author @erfanzar (Erfan Zare Chavoshi).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""vLLM-style Unified (paged) Attention operation.
+
+This operation wraps ejkernel's Triton implementation of vLLM's unified
+attention kernel (paged KV cache + ragged queries).
+
+Notes:
+    - Inference-oriented: the underlying kernel is causal-only.
+    - Cache *updates* are handled by the cache view's `concatenate_to_cache(...)`
+      (called from `AttentionModule.concatenate(...)`). This op assumes the KV
+      cache already contains the current step's K/V for the query tokens.
+"""
+
+from __future__ import annotations
+
+import jax
+from ejkernel.modules import unified_attention
+from jax import numpy as jnp
+from jaxtyping import Array, Float
+
+from easydel.layers.caching import OperationsMetadata, RaggedPagesMetadata, unwrap_metadata
+from easydel.layers.caching.unified_attention import UnifiedAttentionCacheView
+
+from .._attention_outputs import AttentionOutput
+from .._operation_impl import OperationImpl, OperationMetadata, OperationRegistry
+from ..requirements import CacheType, ExecutionMode, MetadataField, OperationRequirements, RequirementsBuilder
+
+
+@OperationRegistry.register
+class UnifiedAttn(OperationImpl):
+    """UnifiedAttention (paged) operation backed by Triton."""
+
+    @classmethod
+    def get_impl_name(cls) -> str | tuple[str]:
+        return "unified_attention"
+
+    def get_impl_metadata(self) -> OperationMetadata:
+        return self.metadata
+
+    @classmethod
+    def get_requirements(cls, mode: ExecutionMode = ExecutionMode.MIXED) -> OperationRequirements:
+        return (
+            RequirementsBuilder("unified_attention")
+            .require_metadata(
+                MetadataField.SEQ_LENS
+                | MetadataField.CONTEXT_LENS
+                | MetadataField.POSITIONS
+                | MetadataField.QUERY_START_LOC
+                | MetadataField.PAGES_TABLES
+                | MetadataField.SLOT_MAPPING
+            )
+            .optional_metadata(MetadataField.LOGITS_INDICES)
+            .support_cache(CacheType.RAGGED_PAGES)
+            .use_cache_view(UnifiedAttentionCacheView)
+            .build()
+        )
+
+    def forward_native(
+        self,
+        query: Float[Array, "... num_q_heads head_dim"],
+        cache_view: UnifiedAttentionCacheView,
+        cache_metadata: RaggedPagesMetadata | OperationsMetadata,
+        softmax_scale: float | None = None,
+        causal: bool = True,
+        sliding_window: int | None = None,
+        logits_soft_cap: float | None = None,
+        **ignore,
+    ) -> AttentionOutput:
+        if jax.default_backend() != "gpu":
+            raise NotImplementedError("UnifiedAttn currently requires a GPU backend (Triton).")
+
+        if cache_view is None:
+            raise ValueError("UnifiedAttn requires `cache_view` (paged KV cache).")
+
+        # Unwrap OperationsMetadata -> RaggedPagesMetadata (reuses the same runtime fields).
+        cache_metadata = unwrap_metadata(cache_metadata, "ragged")
+
+        # Flatten to ragged `[total_tokens, heads, dim]` (works for `[B,T,H,D]` and `[B,H,D]`).
+        query_in = query
+        orig_is_4d = query_in.ndim == 4
+        if orig_is_4d:
+            batch, seqlen, num_heads, head_dim = query_in.shape
+        query_ragged = query_in.reshape(-1, *query_in.shape[-2:])
+
+        cfg = self.metadata.get_operation_config("unified_attention")
+        out = unified_attention(
+            query_ragged.astype(self.metadata.runtime_dtype),
+            cache_view.key_cache,
+            cache_view.value_cache,
+            cache_metadata.context_lens.astype(jnp.int32),
+            cache_metadata.pages_tables.astype(jnp.int32),
+            cache_metadata.query_start_loc.astype(jnp.int32),
+            softmax_scale=softmax_scale,
+            causal=causal,
+            sliding_window=sliding_window,
+            logits_soft_cap=logits_soft_cap,
+            platform="triton",
+            cfg=cfg,
+        )
+
+        if orig_is_4d:
+            out = out.reshape(batch, seqlen, num_heads, head_dim)
+
+        return AttentionOutput(attention_weights=None, attention_outputs=out, cache_view=cache_view)

--- a/easydel/utils/readme_generator.py
+++ b/easydel/utils/readme_generator.py
@@ -165,6 +165,7 @@ _ATTN_ENUM_BY_MECHANISM_KEY: dict[str, str] = {
     "page_attention": "PAGED_ATTENTION",
     "ragged_page_attention_v2": "RAGGED_PAGE_ATTENTION_V2",
     "ragged_page_attention_v3": "RAGGED_PAGE_ATTENTION_V3",
+    "unified_attention": "UNIFIED_ATTENTION",
     "autoregressive_decodeattn": "REGRESSIVE_DECODE",
     "autoregressive_decode": "REGRESSIVE_DECODE",
 }
@@ -207,6 +208,7 @@ EASYDEL_TRAINER_README_TEMPLATE = """
     "paged": "RAGGED_PAGE_ATTENTION_V3", "paged_attn": "RAGGED_PAGE_ATTENTION_V3", "paged_attention": "RAGGED_PAGE_ATTENTION_V3",
     "page_attention": "PAGED_ATTENTION",
     "ragged_page_attention_v3": "RAGGED_PAGE_ATTENTION_V3", "ragged_page_attention_v2": "RAGGED_PAGE_ATTENTION_V2",
+    "unified_attention": "UNIFIED_ATTENTION",
     "autoregressive_decodeattn": "REGRESSIVE_DECODE", "autoregressive_decode": "REGRESSIVE_DECODE"
 } %}
 {%- set attn_enum = attn_enum_map.get(model.attn_mechanism_str.lower(), "AUTO") %}


### PR DESCRIPTION
- Introduced unified attention mechanism (vLLM-style) in the attention layers.
- Added UnifiedAttentionCache, UnifiedAttentionCacheConfig, and UnifiedAttentionCacheView for managing the unified attention KV cache.
- Updated existing attention mechanisms to support unified attention in various components, including the scheduler, generation mixin, and operations.
- Enhanced the EasyGenerationMixin to initialize and manage unified attention caches.
- Updated documentation and type hints to reflect the new unified attention mechanism.
- Ensured compatibility with eSurge inference engine for unified attention.