### PR TITLE
fix(trainer): properly upgrade graphother trace context in loss_fn

### DIFF
--- a/easydel/trainers/trainer/_fn.py
+++ b/easydel/trainers/trainer/_fn.py
@@ -110,7 +110,12 @@ def training_step(
         """
         if straight_through_emulator is not None:
             tree = straight_through_emulator(tree)
-        module = state.merge(tree)
+        tree_other = jax.tree_util.tree_map(
+            lambda x: jax.lax.stop_gradient(jax.numpy.asarray(x)) if hasattr(x, "shape") else x, 
+            state.graphother
+        )
+        from flax import nnx as nn
+        module = nn.merge(state.graphdef, tree, tree_other)
         # Prepare inputs for the model call.
         call_batch = module.prepare_inputs_for_call(**minibatch)
         labels = call_batch.pop("labels", None)


### PR DESCRIPTION
This PR fixes a bug where models with `Dropout` crash during training in [minibatch_call](https://github.com/erfanzar/EasyDeL/blob/403e66300a3866c5e85cb24a1081bd07325a47e2/easydel/trainers/training_utils.py#L404). 

Because `state.graphother` (holding mutable states like `RngCount`) is captured from an outer trace context, JAX trace validation fails inside [loss_fn](https://github.com/erfanzar/EasyDeL/blob/403e66300a3866c5e85cb24a1081bd07325a47e2/easydel/trainers/trainer/_fn.py#L94) and [evaluation_step](https://github.com/erfanzar/EasyDeL/blob/403e66300a3866c5e85cb24a1081bd07325a47e2/easydel/trainers/trainer/_fn.py#L146).

Resolves #255.