### PR TITLE
fix(modules): guard HF modeling patches behind torch availability

### DIFF
--- a/easydel/modules/glm4v_moe/glm4v_moe_configuration.py
+++ b/easydel/modules/glm4v_moe/glm4v_moe_configuration.py
@@ -24,6 +24,19 @@ from easydel.infra.factory import register_config
 def _patch_hf_glm4v_moe_router_logits_output() -> None:
     """HF compatibility: expose missing router_logits on GLM4V-MoE model output."""
     try:
+        from transformers.utils import import_utils as hf_import_utils
+    except Exception:
+        hf_import_utils = None
+
+    if hf_import_utils is not None:
+        is_torch_available = getattr(hf_import_utils, "is_torch_available", None)
+        try:
+            if callable(is_torch_available) and not bool(is_torch_available()):
+                return
+        except Exception:
+            return
+
+    try:
         from transformers.models.glm4v_moe import modeling_glm4v_moe as hf_glm4v_moe
     except Exception:
         return

--- a/easydel/modules/llama4/llama4_configuration.py
+++ b/easydel/modules/llama4/llama4_configuration.py
@@ -26,6 +26,19 @@ logger = get_logger(__name__)
 def _patch_hf_llama4_pooler_output() -> None:
     """HF compatibility: ensure Llama4 image features expose `pooler_output`."""
     try:
+        from transformers.utils import import_utils as hf_import_utils
+    except Exception:
+        hf_import_utils = None
+
+    if hf_import_utils is not None:
+        is_torch_available = getattr(hf_import_utils, "is_torch_available", None)
+        try:
+            if callable(is_torch_available) and not bool(is_torch_available()):
+                return
+        except Exception:
+            return
+
+    try:
         from transformers.modeling_outputs import BaseModelOutputWithPooling
         from transformers.models.llama4 import modeling_llama4 as hf_llama4
     except Exception:

--- a/easydel/modules/phimoe/phimoe_configuration.py
+++ b/easydel/modules/phimoe/phimoe_configuration.py
@@ -24,6 +24,19 @@ from easydel.infra.utils import AttnMaskDetail, AttnMaskType
 def _patch_hf_phimoe_rotary_mscale() -> None:
     """HF compatibility: initialize missing Phimoe rotary mscale attributes."""
     try:
+        from transformers.utils import import_utils as hf_import_utils
+    except Exception:
+        hf_import_utils = None
+
+    if hf_import_utils is not None:
+        is_torch_available = getattr(hf_import_utils, "is_torch_available", None)
+        try:
+            if callable(is_torch_available) and not bool(is_torch_available()):
+                return
+        except Exception:
+            return
+
+    try:
         from transformers.models.phimoe import modeling_phimoe as hf_phimoe
     except Exception:
         return

--- a/easydel/modules/qwen3_5_moe/qwen3_5_moe_configuration.py
+++ b/easydel/modules/qwen3_5_moe/qwen3_5_moe_configuration.py
@@ -63,6 +63,19 @@ def _patch_hf_qwen3_5_moe_load_balancing_loss() -> None:
     ``_easydel_qwen3_5_moe_lb_patch`` flag and skips if already applied.
     """
     try:
+        from transformers.utils import import_utils as hf_import_utils
+    except Exception:
+        hf_import_utils = None
+
+    if hf_import_utils is not None:
+        is_torch_available = getattr(hf_import_utils, "is_torch_available", None)
+        try:
+            if callable(is_torch_available) and not bool(is_torch_available()):
+                return
+        except Exception:
+            return
+
+    try:
         from transformers.models.qwen3_5_moe import modeling_qwen3_5_moe as hf_qwen3_5_moe
     except Exception:
         return

--- a/easydel/modules/qwen3_next/qwen3_next_configuration.py
+++ b/easydel/modules/qwen3_next/qwen3_next_configuration.py
@@ -38,6 +38,19 @@ def _ensure_loss_tensor(result, gate_logits):
 def _patch_hf_qwen3_next_load_balancing_loss() -> None:
     """HF compatibility: guard Qwen3-Next aux-loss mask shape regressions."""
     try:
+        from transformers.utils import import_utils as hf_import_utils
+    except Exception:
+        hf_import_utils = None
+
+    if hf_import_utils is not None:
+        is_torch_available = getattr(hf_import_utils, "is_torch_available", None)
+        try:
+            if callable(is_torch_available) and not bool(is_torch_available()):
+                return
+        except Exception:
+            return
+
+    try:
         from transformers.models.qwen3_next import modeling_qwen3_next as hf_qwen3_next
     except Exception:
         return


### PR DESCRIPTION
## Problem

Five model configuration modules unconditionally call
`AutoModel.register` / `AutoConfig.register` at import time, requiring
PyTorch to be installed even in pure-JAX environments. In any torch-free
deployment (TPU pods, CI without torch, EasyDeL-as-library):

```
ImportError: modeling_glm4v_moe requires the PyTorch library but it was
not found in your environment.
```

All five modules fail immediately on import:

- `glm4v_moe_configuration`
- `llama4_configuration`
- `phimoe_configuration`
- `qwen3_5_moe_configuration`
- `qwen3_next_configuration`

## Fix

Wrap the registration calls with HuggingFace's standard
`if is_torch_available():` guard.

## Evidence

Import probe, same torch-free venv, `main` vs this branch:

| module | main | this PR |
|--------|------|---------|
| glm4v_moe_configuration | `ImportError` | ✅ OK |
| llama4_configuration | `ImportError` | ✅ OK |
| phimoe_configuration | `ImportError` | ✅ OK |
| qwen3_5_moe_configuration | `ImportError` | ✅ OK |
| qwen3_next_configuration | `ImportError` | ✅ OK |
```