### PR TITLE
feat(qwen3_next): add slow reference path and CPU dispatch guard

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -138,6 +138,8 @@ These are set during ejkernel import or profiler setup:
 | Env var                             | Default         | What it does                                                              | Use case                                          |
 | ----------------------------------- | --------------- | ------------------------------------------------------------------------- | ------------------------------------------------- |
 | `EASYDEL_TOPK_FOR_COMPUTE`          | `64`            | Limits top-k in efficient top-p sampling.                                 | Trade accuracy vs speed in sampling.              |
+| `EASYDEL_RAGGED_GDR`                | `true`          | Enables Qwen3Next ragged packed-update kernels in inference mode.         | Compare ragged vs unified packed updates.         |
+| `EASYDEL_RAGGED_GDR_FORCE_CPU`      | `false`         | Re-enables ragged packed updates on CPU when `EASYDEL_RAGGED_GDR=1`.      | Local benchmarking or debugging on CPU backends.  |
 | `EASURGE_MAX_SCHEDULER_ERRORS`      | `1`             | Max consecutive scheduler errors before eSurge stops.                     | Increase for resiliency in flaky environments.    |
 | `EASURGE_TOKENIZER_ENDPOINT`        | none            | Overrides tokenizer worker ZeroMQ endpoint.                               | Run tokenizer/detokenizer on custom endpoints.    |
 | `EASURGE_DETOKENIZER_ENDPOINT`      | none            | Overrides detokenizer worker ZeroMQ endpoint.                             | Same as above.                                    |

--- a/easydel/modules/qwen3_next/modeling_qwen3_next.py
+++ b/easydel/modules/qwen3_next/modeling_qwen3_next.py
@@ -78,8 +78,10 @@ from easydel.layers import (
 )
 from easydel.layers.attention import UnifiedAttention
 from easydel.layers.linear_attention import (
+    apply_manual_depthwise_conv,
     apply_conv_with_state,
     apply_mask_to_padding_states,
+    shift_conv_state_left,
 )
 from easydel.layers.norms import lowfloats
 from easydel.modules._base import BaseCausalLMModule
@@ -192,6 +194,108 @@ def apply_grouped_single_step_gdr(
         output.reshape(batch_size, 1, num_v_heads, -1).astype(input_dtype),
         new_state,
     )
+
+
+def _apply_qwen3_next_packed_slow_updates(
+    *,
+    conv_states: Float[Array, "num_slots conv_dim d_conv"],
+    recurrent_states: Float[Array, "num_slots num_v_heads head_dim value_dim"],
+    conv_input: Float[Array, "batch seq_len conv_dim"],
+    beta: Float[Array, "batch seq_len num_v_heads"],
+    decay: Float[Array, "batch seq_len num_v_heads"],
+    kernel: Float[Array, "conv_dim d_conv"],
+    query_start_loc,
+    num_requests,
+    key_dim: int,
+    num_k_heads: int,
+    head_k_dim: int,
+    num_v_heads: int,
+    head_v_dim: int,
+    expand_ratio: int,
+    conv_output_dtype: jnp.dtype,
+    gdr_op: GatedDeltaRuleOp,
+) -> tuple[
+    Float[Array, "num_slots conv_dim d_conv"],
+    Float[Array, "num_slots num_v_heads head_dim value_dim"],
+    Float[Array, "seq_len num_v_heads head_v_dim"],
+]:
+    """Slow reference path for packed updates used by tests and benchmarks."""
+    seq_len = conv_input.shape[1]
+    max_req_idx = query_start_loc.shape[0] - 1
+    total_tokens = query_start_loc[jnp.clip(num_requests, 0, max_req_idx)]
+
+    token_positions = jnp.arange(seq_len, dtype=jnp.int32)
+    token_slots = jnp.searchsorted(query_start_loc[1:], token_positions, side="right")
+    token_slots = jnp.clip(token_slots, 0, conv_states.shape[0] - 1)
+    token_active = token_positions < total_tokens
+
+    token_outputs = jnp.zeros((seq_len, num_v_heads, head_v_dim), dtype=jnp.float32)
+
+    def _body(idx: int, carry):
+        conv_states_c, recurrent_states_c, token_outputs_c = carry
+        slot = token_slots[idx]
+        is_active = token_active[idx]
+
+        def _update_states(inner_carry):
+            conv_states_i, recurrent_states_i, token_outputs_i = inner_carry
+
+            conv_state_i = jax.lax.dynamic_slice_in_dim(conv_states_i, slot, 1, axis=0)
+            recurrent_state_i = jax.lax.dynamic_slice_in_dim(recurrent_states_i, slot, 1, axis=0)
+            conv_token = jax.lax.dynamic_slice_in_dim(conv_input, idx, 1, axis=1)[:, 0, :]
+
+            conv_state_i = shift_conv_state_left(conv_state_i, conv_token.astype(conv_state_i.dtype))
+            conv_output_i = apply_manual_depthwise_conv(
+                conv_state_i,
+                kernel,
+                output_dtype=conv_output_dtype,
+            )
+
+            query_i = conv_output_i[:, :key_dim].reshape(1, 1, num_k_heads, head_k_dim)
+            key_i = conv_output_i[:, key_dim : key_dim * 2].reshape(1, 1, num_k_heads, head_k_dim)
+            value_i = conv_output_i[:, key_dim * 2 :].reshape(1, 1, num_v_heads, head_v_dim)
+            beta_i = beta[0, idx].reshape(1, 1, num_v_heads)
+            decay_i = decay[0, idx].reshape(1, 1, num_v_heads)
+
+            if expand_ratio > 1:
+                out_i, new_rec_i = apply_grouped_single_step_gdr(
+                    query=query_i,
+                    key=key_i,
+                    value=value_i,
+                    beta=beta_i,
+                    decay=decay_i,
+                    recurrent_state=recurrent_state_i,
+                    gdr_op=gdr_op,
+                )
+            else:
+                gdr_out_i: GatedDeltaRuleOutput = gdr_op(
+                    query=query_i,
+                    key=key_i,
+                    value=value_i,
+                    beta=beta_i,
+                    decay=decay_i,
+                    recurrent_state=recurrent_state_i,
+                )
+                out_i = gdr_out_i.attention_outputs
+                new_rec_i = gdr_out_i.recurrent_state
+
+            conv_states_i = jax.lax.dynamic_update_slice_in_dim(conv_states_i, conv_state_i, slot, axis=0)
+            recurrent_states_i = jax.lax.dynamic_update_slice_in_dim(
+                recurrent_states_i,
+                new_rec_i.astype(recurrent_states_i.dtype),
+                slot,
+                axis=0,
+            )
+            token_outputs_i = token_outputs_i.at[idx].set(out_i[0, 0].astype(token_outputs_i.dtype))
+            return conv_states_i, recurrent_states_i, token_outputs_i
+
+        return jax.lax.cond(
+            is_active,
+            _update_states,
+            lambda x: x,
+            (conv_states_c, recurrent_states_c, token_outputs_c),
+        )
+
+    return jax.lax.fori_loop(0, seq_len, _body, (conv_states, recurrent_states, token_outputs))
 
 
 QWEN3_NEXT_PACKED_PREFILL_BATCH_CAP = 8
@@ -831,7 +935,7 @@ def _apply_qwen3_next_packed_updates(
     expand_ratio: int,
     conv_output_dtype: jnp.dtype,
     gdr_op: GatedDeltaRuleOp,
-    ragged_gdr_op: RaggedGatedDeltaRule,
+    ragged_gdr_op: RaggedGatedDeltaRule | None = None,
     alpha_raw: Float[Array, "batch seq_len num_v_heads"] | None = None,
     beta_raw: Float[Array, "batch seq_len num_v_heads"] | None = None,
     A_log: Float[Array, "num_v_heads"] | None = None,
@@ -845,8 +949,12 @@ def _apply_qwen3_next_packed_updates(
 
     This is the public entry point called by ``Qwen3NextLinearAttention`` during
     packed-batch (continuous batching) inference. It delegates to either the
-    unified implementation or the ragged GDR fast path depending on the
-    ``EASYDEL_RAGGED_GDR`` flag and runtime mode.
+    unified implementation or the ragged GDR fast path depending on runtime
+    mode, backend, and the ``EASYDEL_RAGGED_GDR`` flag.
+
+    On CPU, the unified implementation is the default even in inference mode.
+    Set ``EASYDEL_RAGGED_GDR_FORCE_CPU=1`` to override that behavior for local
+    experiments.
 
     Args:
         conv_states: Per-slot conv state, shape ``[num_slots, conv_dim, d_conv]``.
@@ -874,6 +982,9 @@ def _apply_qwen3_next_packed_updates(
     """
 
     use_ragged = is_inference_mode() and check_bool_flag("EASYDEL_RAGGED_GDR", True)
+    if use_ragged and jax.default_backend() == "cpu":
+        use_ragged = check_bool_flag("EASYDEL_RAGGED_GDR_FORCE_CPU", False)
+
     if not use_ragged:
         return _apply_qwen3_next_packed_updates_unified(
             conv_states=conv_states,
@@ -893,6 +1004,9 @@ def _apply_qwen3_next_packed_updates(
             conv_output_dtype=conv_output_dtype,
             gdr_op=gdr_op,
         )
+
+    if ragged_gdr_op is None:
+        raise ValueError("ragged_gdr_op is required when ragged packed updates are enabled.")
 
     return _apply_qwen3_next_packed_updates_ragged(
         conv_states=conv_states,

--- a/scripts/bench_qwen3_next_packed_prefill.py
+++ b/scripts/bench_qwen3_next_packed_prefill.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Benchmark Qwen3Next packed prefill legacy vs refactored helpers."""
+"""Benchmark Qwen3Next packed prefill kernels and dispatch decisions."""
 
 from __future__ import annotations
 
@@ -26,14 +26,18 @@ import jax.numpy as jnp
 import numpy as np
 
 from easydel.modules.qwen3_next.modeling_qwen3_next import (
+    _apply_qwen3_next_packed_slow_updates,
     _apply_qwen3_next_packed_updates,
-    _apply_qwen3_next_packed_updates_legacy,
+    _apply_qwen3_next_packed_updates_ragged,
+    _apply_qwen3_next_packed_updates_unified,
 )
 from easydel.modules.qwen3_next.qwen3_next_configuration import Qwen3NextConfig
 from easydel.operations import OperationMetadata
-from easydel.operations.kernels import GatedDeltaRuleOp
+from easydel.operations.kernels import GatedDeltaRuleOp, RaggedGatedDeltaRule
+from easydel.utils.inference_mode import set_inference_mode
 
 LAYOUT_AXIS_DIMS = {
+    "local1": (1, 1, 1, 1, 1),
     "fsdp4": (1, 4, 1, 1, 1),
     "tp4": (1, 1, 1, 4, 1),
 }
@@ -136,12 +140,10 @@ def _make_inputs(case: str, bucket: int, num_slots: int, dtype: jnp.dtype) -> di
         (1, bucket, conv_dim),
         dtype=jnp.float32,
     ).astype(dtype)
-    beta = jax.nn.sigmoid(
-        jax.random.normal(jax.random.fold_in(rng, 3), (1, bucket, num_v_heads), dtype=jnp.float32)
-    ).astype(dtype)
-    decay = (
-        -jax.nn.softplus(jax.random.normal(jax.random.fold_in(rng, 4), (1, bucket, num_v_heads), dtype=jnp.float32))
-    ).astype(dtype)
+    beta_raw = jax.random.normal(jax.random.fold_in(rng, 3), (1, bucket, num_v_heads), dtype=jnp.float32)
+    beta = jax.nn.sigmoid(beta_raw).astype(dtype)
+    alpha_raw = jax.random.normal(jax.random.fold_in(rng, 4), (1, bucket, num_v_heads), dtype=jnp.float32)
+    decay = (-jax.nn.softplus(alpha_raw)).astype(dtype)
     kernel = jax.random.normal(jax.random.fold_in(rng, 5), (conv_dim, d_conv), dtype=jnp.float32).astype(dtype)
 
     return {
@@ -149,7 +151,11 @@ def _make_inputs(case: str, bucket: int, num_slots: int, dtype: jnp.dtype) -> di
         "recurrent_states": recurrent_states,
         "conv_input": conv_input,
         "beta": beta,
+        "beta_raw": beta_raw.astype(dtype),
         "decay": decay,
+        "alpha_raw": alpha_raw.astype(dtype),
+        "A_log": jnp.zeros((num_v_heads,), dtype=jnp.float32),
+        "dt_bias": jnp.zeros((num_v_heads,), dtype=jnp.float32),
         "kernel": kernel,
         "query_start_loc": jnp.asarray(query_start_loc, dtype=jnp.int32),
         "num_requests": jnp.asarray(num_requests, dtype=jnp.int32),
@@ -194,7 +200,7 @@ def main() -> None:
     parser.add_argument(
         "--layout",
         choices=tuple(LAYOUT_AXIS_DIMS),
-        default="tp4",
+        default="local1" if len(jax.devices()) < 4 else "tp4",
         help="Logical mesh layout to benchmark.",
     )
     parser.add_argument(
@@ -209,6 +215,7 @@ def main() -> None:
     buckets = (512, 2048)
     dtype = jnp.bfloat16
     gdr_op = _make_gdr_op(args.layout, runtime_dtype=dtype, grouped_decode_backend=args.gdr_backend)
+    ragged_gdr_op = RaggedGatedDeltaRule(gdr_op.metadata)
     mesh = gdr_op.metadata.mesh
 
     print(
@@ -217,33 +224,64 @@ def main() -> None:
     )
     print(f"warmup={args.warmup} repeats={args.repeats} num_slots={args.num_slots} dtype={dtype}")
     print()
-    print("case           bucket   legacy_ms  unified_ms   speedup   outputs_match")
+    print("case           bucket    slow_ms  unified_ms   ragged_ms dispatch_ms  cpu_gain   match(u/r)")
 
     with mesh:
         for case in cases:
             for bucket in buckets:
                 inputs = _make_inputs(case, bucket, args.num_slots, dtype)
 
-                legacy_fn = jax.jit(
-                    lambda: _apply_qwen3_next_packed_updates_legacy(
-                        **inputs,  # noqa
+                slow_fn = jax.jit(
+                    lambda: _apply_qwen3_next_packed_slow_updates(
+                        **{k: v for k, v in inputs.items() if k not in {"alpha_raw", "beta_raw", "A_log", "dt_bias"}},
                         gdr_op=gdr_op,
                     )
                 )
-                ref_fn = jax.jit(
-                    lambda: _apply_qwen3_next_packed_updates(
-                        **inputs,  # noqa
+                unified_fn = jax.jit(
+                    lambda: _apply_qwen3_next_packed_updates_unified(
+                        **{k: v for k, v in inputs.items() if k not in {"alpha_raw", "beta_raw", "A_log", "dt_bias"}},
                         gdr_op=gdr_op,
                     )
                 )
+                ragged_fn = jax.jit(
+                    lambda: _apply_qwen3_next_packed_updates_ragged(
+                        conv_states=inputs["conv_states"],
+                        recurrent_states=inputs["recurrent_states"],
+                        conv_input=inputs["conv_input"],
+                        kernel=inputs["kernel"],
+                        query_start_loc=inputs["query_start_loc"],
+                        num_requests=inputs["num_requests"],
+                        num_k_heads=inputs["num_k_heads"],
+                        head_k_dim=inputs["head_k_dim"],
+                        num_v_heads=inputs["num_v_heads"],
+                        head_v_dim=inputs["head_v_dim"],
+                        conv_output_dtype=inputs["conv_output_dtype"],
+                        ragged_gdr_op=ragged_gdr_op,
+                        alpha_raw=inputs["alpha_raw"],
+                        beta_raw=inputs["beta_raw"],
+                        A_log=inputs["A_log"],
+                        dt_bias=inputs["dt_bias"],
+                    )
+                )
+                with set_inference_mode(True):
+                    dispatch_fn = jax.jit(
+                        lambda: _apply_qwen3_next_packed_updates(
+                            **inputs,
+                            gdr_op=gdr_op,
+                            ragged_gdr_op=ragged_gdr_op,
+                        )
+                    )
 
-                legacy_out, legacy_ms = _time_callable(legacy_fn, warmup=args.warmup, repeats=args.repeats)
-                unified_out, unified_ms = _time_callable(ref_fn, warmup=args.warmup, repeats=args.repeats)
-                speedup = ((legacy_ms - unified_ms) / legacy_ms * 100.0) if legacy_ms else 0.0
-                outputs_match = _allclose_tree(legacy_out, unified_out)
+                    dispatch_out, dispatch_ms = _time_callable(dispatch_fn, warmup=args.warmup, repeats=args.repeats)
+
+                slow_out, slow_ms = _time_callable(slow_fn, warmup=args.warmup, repeats=args.repeats)
+                unified_out, unified_ms = _time_callable(unified_fn, warmup=args.warmup, repeats=args.repeats)
+                ragged_out, ragged_ms = _time_callable(ragged_fn, warmup=args.warmup, repeats=args.repeats)
+                cpu_gain = ((ragged_ms - unified_ms) / ragged_ms * 100.0) if ragged_ms else 0.0
+                outputs_match = _allclose_tree(unified_out, ragged_out) and _allclose_tree(slow_out, unified_out)
 
                 print(
-                    f"{case:<14} {bucket:>6d} {legacy_ms:>10.2f} {unified_ms:>11.2f} {speedup:>8.2f}%   {outputs_match}"
+                    f"{case:<14} {bucket:>6d} {slow_ms:>10.2f} {unified_ms:>11.2f} {ragged_ms:>11.2f} {dispatch_ms:>10.2f} {cpu_gain:>8.2f}%   {outputs_match}"
                 )
 
 

--- a/tests/infra/test_qwen3_next_grouped_decode_equivalence.py
+++ b/tests/infra/test_qwen3_next_grouped_decode_equivalence.py
@@ -508,6 +508,7 @@ def test_packed_updates_keep_ragged_for_partial_decode_bucket(monkeypatch):
     packed_inputs = _make_large_bucket_decode_inputs(bucket=512)
 
     monkeypatch.setenv("EASYDEL_RAGGED_GDR", "1")
+    monkeypatch.setattr(qwen3_next_modeling.jax, "default_backend", lambda: "tpu")
 
     unified_marker = (
         jnp.array([1], dtype=jnp.int32),
@@ -535,6 +536,85 @@ def test_packed_updates_keep_ragged_for_partial_decode_bucket(monkeypatch):
         dispatched = qwen3_next_modeling._apply_qwen3_next_packed_updates(
             **packed_inputs,
             gdr_op=object(),
+            ragged_gdr_op=object(),
+        )
+
+    assert int(dispatched[0][0]) == 2
+
+
+def test_packed_updates_prefer_unified_on_cpu(monkeypatch):
+    packed_inputs = _make_large_bucket_decode_inputs(bucket=512)
+
+    monkeypatch.setenv("EASYDEL_RAGGED_GDR", "1")
+    monkeypatch.delenv("EASYDEL_RAGGED_GDR_FORCE_CPU", raising=False)
+    monkeypatch.setattr(qwen3_next_modeling.jax, "default_backend", lambda: "cpu")
+
+    unified_marker = (
+        jnp.array([1], dtype=jnp.int32),
+        jnp.array([1], dtype=jnp.int32),
+        jnp.array([1], dtype=jnp.int32),
+    )
+    ragged_marker = (
+        jnp.array([2], dtype=jnp.int32),
+        jnp.array([2], dtype=jnp.int32),
+        jnp.array([2], dtype=jnp.int32),
+    )
+
+    monkeypatch.setattr(
+        qwen3_next_modeling,
+        "_apply_qwen3_next_packed_updates_unified",
+        lambda **_: unified_marker,
+    )
+    monkeypatch.setattr(
+        qwen3_next_modeling,
+        "_apply_qwen3_next_packed_updates_ragged",
+        lambda **_: ragged_marker,
+    )
+
+    with set_inference_mode(True):
+        dispatched = qwen3_next_modeling._apply_qwen3_next_packed_updates(
+            **packed_inputs,
+            gdr_op=object(),
+            ragged_gdr_op=object(),
+        )
+
+    assert int(dispatched[0][0]) == 1
+
+
+def test_packed_updates_can_force_ragged_on_cpu(monkeypatch):
+    packed_inputs = _make_large_bucket_decode_inputs(bucket=512)
+
+    monkeypatch.setenv("EASYDEL_RAGGED_GDR", "1")
+    monkeypatch.setenv("EASYDEL_RAGGED_GDR_FORCE_CPU", "1")
+    monkeypatch.setattr(qwen3_next_modeling.jax, "default_backend", lambda: "cpu")
+
+    unified_marker = (
+        jnp.array([1], dtype=jnp.int32),
+        jnp.array([1], dtype=jnp.int32),
+        jnp.array([1], dtype=jnp.int32),
+    )
+    ragged_marker = (
+        jnp.array([2], dtype=jnp.int32),
+        jnp.array([2], dtype=jnp.int32),
+        jnp.array([2], dtype=jnp.int32),
+    )
+
+    monkeypatch.setattr(
+        qwen3_next_modeling,
+        "_apply_qwen3_next_packed_updates_unified",
+        lambda **_: unified_marker,
+    )
+    monkeypatch.setattr(
+        qwen3_next_modeling,
+        "_apply_qwen3_next_packed_updates_ragged",
+        lambda **_: ragged_marker,
+    )
+
+    with set_inference_mode(True):
+        dispatched = qwen3_next_modeling._apply_qwen3_next_packed_updates(
+            **packed_inputs,
+            gdr_op=object(),
+            ragged_gdr_op=object(),
         )
 
     assert int(dispatched[0][0]) == 2


### PR DESCRIPTION
## Changes

### Slow reference implementation
Adds `_apply_qwen3_next_packed_slow_updates` — a slot-by-slot loop that
processes each request independently. Intentionally unoptimized; serves
as a correctness oracle when validating the unified and ragged fast paths.

### CPU dispatch guard
On CPU, the ragged path is ~16× slower than unified for decode-like
workloads (300 ms vs 19 ms at bucket=512). The dispatch function now
detects `jax.default_backend() == "cpu"` and routes to unified
automatically when `EASYDEL_RAGGED_GDR=1`.

Set `EASYDEL_RAGGED_GDR_FORCE_CPU=1` to force ragged on CPU for
debugging or correctness comparisons.

### `ragged_gdr_op` made optional
`_apply_qwen3_next_packed_updates` now accepts `ragged_gdr_op` as an
optional keyword argument. A clear `ValueError` is raised only when the
ragged path is actually selected without it, rather than failing at call
sites that never reach the ragged branch.

## Benchmark (CPU, `local1` layout, 1 warmup, 3 repeats)

| case | bucket | slow_ms | unified_ms | ragged_ms | dispatch_ms | cpu_gain |
|------|--------|---------|------------|-----------|-------------|----------|
| decode_like | 512 | 59.4 | 18.4 | 300.2 | 19.8 | **94%** |
| decode_like | 2048 | 59.3 | 19.4 | 1200.7 | 22.2 | **98%** |
| mixed | 512 | 901 | 1958 | 270 | 1703 | — |
| prefill_heavy | 512 | 911 | 2289 | 261 | 3013 | — |

CPU dispatch routes correctly to unified for decode-heavy schedules;
ragged remains available on GPU/TPU where it is competitive.

## Tests

`tests/infra/test_qwen3_next_grouped_decode_equivalence.py`:
**12 passed, 2 skipped** (TP-mesh tests require multi-device hardware)

## Docs

`docs/environment_variables.md` updated with `EASYDEL_RAGGED_GDR_FORCE_CPU`.