### PR TITLE
fix(generation): fp4 byte-size and stale v1→v2 MLA warning

### DIFF
--- a/easydel/infra/mixins/generation.py
+++ b/easydel/infra/mixins/generation.py
@@ -509,7 +509,7 @@ def _create_mixed_standard_ragged_page_cache_configs(
             hbm_utilization=hbm_utilization,
             kv_head_shards=effective_kv_head_shards,
         )
-        bytes_av = jnp.finfo(kvdtype).bits // 8
+        bytes_av = jnp.dtype(kvdtype).itemsize
         page_bytes = (
             2
             * int(page_size)
@@ -628,7 +628,7 @@ def _create_mixed_standard_unified_attention_cache_configs(
     mesh = text_config.mesh
     kvdtype = dtype
     data_parallel_size = _mesh_axis_size(mesh, resolve_attention_data_parallel_axis(partition_manager))
-    bytes_av = jnp.finfo(kvdtype).bits // 8
+    bytes_av = jnp.dtype(kvdtype).itemsize
 
     if num_pages_override is None:
         free = UnifiedAttentionCacheConfig._compute_free_hbm(
@@ -4637,7 +4637,7 @@ class EasyGenerationMixin:
                 logger.warning(
                     "Mixed MLA and non-MLA full-attention layers detected, "
                     "forcing all inference layers to "
-                    "multi_latent_ragged_page_attention_v1."
+                    "multi_latent_ragged_page_attention_v2."
                 )
             update_kwargs["decode_attn_mechanism"] = target_attn
             update_kwargs["mla_attn_mechanism"] = target_attn

--- a/tests/inference/test_optional_config_regressions.py
+++ b/tests/inference/test_optional_config_regressions.py
@@ -1044,3 +1044,45 @@ def test_esurge_compatible_model_updates_vlm_text_attn_recursively():
     model = _build_tiny_qwen35_vlm(source_attn)
     compatible = model.esurge_compatible_model
     assert compatible.config.get_text_config().attn_mechanism == expected_attn
+
+
+def test_esurge_compatible_model_logs_v2_for_mixed_mla(monkeypatch):
+    import easydel.infra.mixins.generation as generation_mod
+
+    warnings: list[str] = []
+
+    monkeypatch.setattr(generation_mod, "_resolve_backend_for_esurge", lambda _config: "cpu")
+    monkeypatch.setattr(generation_mod, "_detect_mla_attention_mix", lambda _self, _text_cfg: (True, True))
+    monkeypatch.setattr(
+        generation_mod.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warnings.append(msg % args if args else msg),
+    )
+
+    text_config = SimpleNamespace(num_attention_heads=8, attn_mechanism="sdpa")
+
+    class _DummyModel:
+        def __init__(self):
+            self.config = SimpleNamespace(
+                attn_mechanism="sdpa",
+                get_text_config=lambda: text_config,
+            )
+            self.graphstate = object()
+            self.graphother = object()
+            self.last_update_kwargs = None
+
+        def new_graphdef(self, **kwargs):
+            self.last_update_kwargs = kwargs
+            return kwargs
+
+        def merge_module(self, compat_graphdef, graphstate, graphother):
+            return SimpleNamespace(graphdef=compat_graphdef, graphstate=graphstate, graphother=graphother)
+
+    dummy = _DummyModel()
+    generation_mod.EasyGenerationMixin.esurge_compatible_model.fget(dummy)
+
+    assert dummy.last_update_kwargs is not None
+    assert dummy.last_update_kwargs["attn_mechanism"] == "multi_latent_ragged_page_attention_v2"
+    assert dummy.last_update_kwargs["decode_attn_mechanism"] == "multi_latent_ragged_page_attention_v2"
+    assert dummy.last_update_kwargs["mla_attn_mechanism"] == "multi_latent_ragged_page_attention_v2"
+    assert any("multi_latent_ragged_page_attention_v2" in message for message in warnings)


### PR DESCRIPTION
## Changes

### fp4-safe byte-size calculation
`_create_mixed_standard_ragged_page_cache_configs` and
`_create_mixed_standard_unified_attention_cache_configs` both used
`jnp.finfo(kvdtype).bits // 8` — the same bug fixed in the caching
layer (see PR #XX). Replaced with `jnp.dtype(kvdtype).itemsize` so
fp4 / integer KV dtypes work correctly through the generation mixin too.

### Correct `v1` → `v2` in mixed-MLA log warning
The warning that fires when mixed MLA/non-MLA layers are detected was
logging `multi_latent_ragged_page_attention_v1` as the target mechanism.
The actual target is `v2`. Fixed the string literal.

## Tests

New: `test_esurge_compatible_model_logs_v2_for_mixed_mla` — verifies
that both the emitted warning and the resulting `attn_mechanism` /
`decode_attn_mechanism` / `mla_attn_mechanism` kwargs all reference
`multi_latent_ragged_page_attention_v2`. 1 passed.