### PR TITLE
feat(distillation): add CAKLD (Confidence-Aware KL) blending

### DIFF
--- a/libs/easydel/easydel/infra/elarge/types/training.py
+++ b/libs/easydel/easydel/infra/elarge/types/training.py
@@ -1329,6 +1329,8 @@ class DistillationTrainerCfg(BaseTrainerCfg):
             information about class relationships.
         alpha: Weight for distillation loss relative to task loss.
             alpha * distillation_loss + (1 - alpha) * task_loss.
+        cakld_gamma: Optional Confidence-Aware KL coefficient for
+            CAKLD-style blending of reverse and forward KL.
         logits_chunk_size: Optional sequence-axis chunk size used when
             running the LM head chunk-by-chunk to bound peak memory.
             ``None`` materialises the full ``[B, L, V]`` logit tensor.
@@ -1383,6 +1385,7 @@ class DistillationTrainerCfg(BaseTrainerCfg):
     attention_layers: NotRequired[tuple[int, ...] | None]
     attention_normalize: NotRequired[bool]
     beta: NotRequired[float | None]
+    cakld_gamma: NotRequired[float | None]
     disable_dropout: NotRequired[bool]
     generation_batch_size: NotRequired[int | None]
     lmbda: NotRequired[float]
@@ -2354,6 +2357,7 @@ TRAINER_SPECIFIC_DEFAULTS: dict[str, TrainerConfig] = {
         "trainer_prefix": "Distillation",
         "temperature": 2.0,
         "alpha": 0.9,
+        "cakld_gamma": None,
         "logits_chunk_size": None,
     },
     "on_policy_distillation": {

--- a/libs/easydel/easydel/trainers/distillation_trainer/_fn.py
+++ b/libs/easydel/easydel/trainers/distillation_trainer/_fn.py
@@ -466,6 +466,7 @@ def distillation_loss(
     temperature: float = 4.0,
     alpha: float = 0.9,
     beta: float | None = None,
+    cakld_gamma: float | None = None,
     loss_top_k: int = 0,
     loss_add_tail: bool = False,
     partition_manager: tp.Any = None,
@@ -495,6 +496,12 @@ def distillation_loss(
             Higher values create softer distributions. Default: 4.0
         alpha (float): Weight for distillation loss vs supervised loss.
             1.0 means pure distillation, 0.0 means pure supervised. Default: 0.9
+        beta: Optional generalized Jensen-Shannon interpolation coefficient.
+            Mutually exclusive with ``cakld_gamma``.
+        cakld_gamma: Optional Confidence-Aware KL coefficient. When set,
+            computes ``gamma * KL(p_student || p_teacher) + (1 - gamma) *
+            KL(p_teacher || p_student)``. The scalar is intended to be the
+            precomputed averaged teacher-token confidence described by CAKLD.
 
     Returns:
         tuple[Array, dict[str, Array]]: Scalar loss value combining distillation
@@ -526,6 +533,8 @@ def distillation_loss(
     if labels is not None:
         valid_label_mask = (labels != -100).astype(dtype)
         mask = valid_label_mask if mask is None else mask * valid_label_mask
+    if cakld_gamma is not None and (loss_top_k > 0 or loss_add_tail):
+        raise ValueError("`cakld_gamma` is not supported with `loss_top_k` / `loss_add_tail`.")
 
     # Vocab-parallel reduction. When a ``PartitionManager`` is supplied (and the in-context mesh has a
     # real >1 ``tp`` axis), resolve the semantic ``[BATCH, LENGTH, VOCAB]`` / ``[BATCH, LENGTH]`` specs
@@ -564,77 +573,85 @@ def distillation_loss(
         kl_loss = divergence_loss * temp_sq
     else:
         # ejkernel fused KL: forward KL by default (beta is None), or the generalized
-        # JSD when beta is set. The kernel streams both softmaxes over the vocabulary
-        # without materializing a [..., V] log-softmax and supplies the analytic student
-        # gradient (teacher detached). The loss is already masked-mean * T^2.
-        if beta is None:
-            direction, want_entropy = "forward", True  # KL(p_t || p_s), report entropy split
-        elif beta <= 0.0:
-            direction, want_entropy = "forward", False  # KL(p_t || p_s): GKD/TRL beta->0 limit
-        elif beta >= 1.0:
-            direction, want_entropy = "reverse", False  # KL(p_s || p_t): GKD/TRL beta->1 limit
-        else:
-            direction, want_entropy = "jsd", False
+        # JSD when beta is set, or CAKLD when gamma is set. The kernel streams both
+        # softmaxes over the vocabulary without materializing a [..., V] log-softmax
+        # and supplies the student gradient with the teacher detached. The loss is
+        # already masked-mean * T^2.
+        #
+        # Vocab-parallel KL keeps the full [B, S, V] logits sharded. The XLA backend
+        # supports forward, reverse, and JSD in this mode; TileLang's TP path is
+        # narrower, so EasyDeL forces platform="xla".
+        use_vocab_parallel = _vp_mesh is not None
 
-        # Vocab-parallel KL only applies to forward KL (the kernel's vocab-parallel direction); the
-        # all-reduce it removes -- two ~60GB ``[B, S, V]`` tensors for a 248K vocab -- is the large-vocab
-        # distillation OOM cause.
-        use_vocab_parallel = _vp_mesh is not None and direction == "forward"
-        if use_vocab_parallel:
-            # Vocab-parallel KL via the module op: passing mesh/in_specs/out_specs makes the op wrap the
-            # XLA kernel in ``jax.shard_map`` and reduce the softmax normalizer with a ``psum`` over the TP
-            # axis, so the full unsharded ``[B, S, V]`` logits are NEVER all-reduced. The op infers the vocab
-            # axis from ``in_specs[0]`` (the resolved ``[BATCH, LENGTH, VOCAB]`` spec) and forces
-            # ``check_vma=True``, which the vocab-parallel custom backward needs for an exact gradient
-            # (verified value+grad parity vs dense for T=1/2/4). ``return_teacher_entropy`` is honored even
-            # here: the op computes H(p_t) on the vocab-sharded ``teacher_logits`` outside shard_map, where
-            # ``log_softmax`` keeps the tensor sharded and only the cheap ``[B, S]`` normalizer all-reduces
-            # -- so the metric split (``distill_xent_loss``/``teacher_entropy_loss``) matches the dense path
-            # without re-gathering the full ``[B, S, V]``. ``mask`` is passed straight through (``None`` when
-            # there is none -- the op then needs no weights operand, and a non-None mask drives the kernel's
-            # per-row sparse early-exit so masked rows are skipped).
-            # Pad the leading [batch, seq] dims up to the meshed-axis product so shard_map never hits a
-            # non-divisible micro-batch / sp-indivisible sequence; padded rows carry zero weight so they
-            # drop out of the masked mean (and the teacher-entropy reduction).
-            _kl_pads = _vp_leading_pads(student_logits.shape[:-1], _vp_token_spec, _vp_mesh)
-            _kl_s, _kl_t, _kl_w = student_logits, teacher_logits, mask
-            if any(_kl_pads):
-                if _kl_w is None:
-                    _kl_w = jnp.ones(student_logits.shape[:-1], dtype=jnp.float32)
-                _kl_s = _pad_leading(student_logits, _kl_pads)
-                _kl_t = _pad_leading(teacher_logits, _kl_pads)
-                _kl_w = _pad_leading(_kl_w, _kl_pads, fill=0.0)
-            out = _fused_kl(
-                _kl_s,
-                _kl_t,
-                _kl_w,
-                reduction="mean",
-                direction="forward",
-                temperature=temperature,
-                return_teacher_entropy=want_entropy,
-                platform="xla",
-                mesh=_vp_mesh,
-                in_specs=(_vp_logit_spec, _vp_logit_spec, _vp_token_spec),
-                out_specs=PartitionSpec(),
-            )
-            kl_loss = out.loss.astype(jnp.float32)
-            if want_entropy:
-                teacher_entropy_loss = out.teacher_entropy.astype(jnp.float32)
-                distill_xent_loss = kl_loss + teacher_entropy_loss
-            else:
-                teacher_entropy_loss = jnp.zeros((), dtype=jnp.float32)
-                distill_xent_loss = kl_loss
-        else:
-            out = _fused_kl(
+        def _run_fused_kl(
+            direction: str,
+            *,
+            beta_value: float = 0.5,
+            want_entropy: bool = False,
+        ):
+            if use_vocab_parallel:
+                # Passing mesh/in_specs/out_specs wraps the XLA kernel in shard_map and reduces the softmax
+                # normalizer with psum over TP, so the full unsharded [B, S, V] logits are never all-reduced.
+                # Pad leading [batch, seq] dims up to meshed-axis divisibility; padded rows carry zero weight.
+                _kl_pads = _vp_leading_pads(student_logits.shape[:-1], _vp_token_spec, _vp_mesh)
+                _kl_s, _kl_t, _kl_w = student_logits, teacher_logits, mask
+                if any(_kl_pads):
+                    if _kl_w is None:
+                        _kl_w = jnp.ones(student_logits.shape[:-1], dtype=jnp.float32)
+                    _kl_s = _pad_leading(student_logits, _kl_pads)
+                    _kl_t = _pad_leading(teacher_logits, _kl_pads)
+                    _kl_w = _pad_leading(_kl_w, _kl_pads, fill=0.0)
+                return _fused_kl(
+                    _kl_s,
+                    _kl_t,
+                    _kl_w,
+                    reduction="mean",
+                    direction=direction,
+                    temperature=temperature,
+                    beta=float(beta_value),
+                    return_teacher_entropy=want_entropy,
+                    platform="xla",
+                    mesh=_vp_mesh,
+                    in_specs=(_vp_logit_spec, _vp_logit_spec, _vp_token_spec),
+                    out_specs=PartitionSpec(),
+                )
+            return _fused_kl(
                 student_logits,
                 teacher_logits,
                 mask,
                 reduction="mean",
                 direction=direction,
                 temperature=temperature,
-                beta=(0.5 if beta is None else float(beta)),
+                beta=float(beta_value),
                 return_teacher_entropy=want_entropy,
                 platform="xla",  # XLA is the bandwidth-optimal KL backend on TPU (Pallas loses)
+            )
+
+        if cakld_gamma is not None:
+            gamma = float(cakld_gamma)
+            if not 0.0 <= gamma <= 1.0:
+                raise ValueError("`cakld_gamma` must be within [0, 1] when set.")
+            if beta is not None:
+                raise ValueError("`cakld_gamma` is mutually exclusive with GJSD `beta`.")
+            forward_kl = _run_fused_kl("forward").loss.astype(jnp.float32)
+            reverse_kl = _run_fused_kl("reverse").loss.astype(jnp.float32)
+            gamma_s = jnp.asarray(gamma, dtype=jnp.float32)
+            kl_loss = gamma_s * reverse_kl + (jnp.asarray(1.0, dtype=jnp.float32) - gamma_s) * forward_kl
+            distill_xent_loss = kl_loss
+            teacher_entropy_loss = jnp.zeros((), dtype=jnp.float32)
+        else:
+            if beta is None:
+                direction, want_entropy = "forward", True  # KL(p_t || p_s), report entropy split
+            elif beta <= 0.0:
+                direction, want_entropy = "forward", False  # KL(p_t || p_s): GKD/TRL beta->0 limit
+            elif beta >= 1.0:
+                direction, want_entropy = "reverse", False  # KL(p_s || p_t): GKD/TRL beta->1 limit
+            else:
+                direction, want_entropy = "jsd", False
+            out = _run_fused_kl(
+                direction,
+                beta_value=(0.5 if beta is None else float(beta)),
+                want_entropy=want_entropy,
             )
             kl_loss = out.loss.astype(jnp.float32)
             if want_entropy:
@@ -720,6 +737,7 @@ def mtp_distillation_loss(
     loss_mask: Array | None = None,
     temperature: float = 4.0,
     beta: float | None = None,
+    cakld_gamma: float | None = None,
     partition_manager: tp.Any = None,
 ) -> Array:
     """Soft KD for a Multi-Token-Prediction head.
@@ -739,7 +757,8 @@ def mtp_distillation_loss(
         loss_mask: ``(B, S)`` completion/assistant mask (takes priority).
         temperature: Softmax temperature, shared with the main KD term.
         beta: Same divergence selector as :func:`distillation_loss` (``None`` ->
-            forward KL, ``<=0`` -> reverse, ``>=1`` -> forward, else generalized JSD).
+            forward KL, ``<=0`` -> forward, ``>=1`` -> reverse, else generalized JSD).
+        cakld_gamma: Optional CAKLD coefficient. Mutually exclusive with ``beta``.
 
     Returns:
         Scalar masked-mean divergence (already scaled by ``T**2`` by the kernel).
@@ -757,55 +776,70 @@ def mtp_distillation_loss(
     else:
         mtp_mask = None
 
-    if beta is None or beta <= 0.0:
+    if cakld_gamma is not None:
+        gamma = float(cakld_gamma)
+        if not 0.0 <= gamma <= 1.0:
+            raise ValueError("`cakld_gamma` must be within [0, 1] when set.")
+        if beta is not None:
+            raise ValueError("`cakld_gamma` is mutually exclusive with GJSD `beta`.")
+    elif beta is None or beta <= 0.0:
         direction = "forward"  # GKD/TRL beta->0 limit (and the classic-KD default)
     elif beta >= 1.0:
         direction = "reverse"  # GKD/TRL beta->1 limit
     else:
         direction = "jsd"
 
-    # Vocab-parallel forward KL via shard_map (same mechanism as ``distillation_loss``): keeps the
-    # vocab TP-sharded so the full [B, S, V] MTP logits are never all-reduced. Forward direction only
-    # (the kernel's vocab-parallel direction); reverse/JSD fall through to the dense path below.
-    vp_mesh = _resolve_vocab_parallel_mesh(partition_manager) if direction == "forward" else None
-    if vp_mesh is not None:
-        kl_weights = mtp_mask if mtp_mask is not None else jnp.ones(student_mtp_logits.shape[:-1], dtype=jnp.float32)
-        logit_spec = partition_manager.resolve([BATCH, LENGTH, VOCAB], MODE_TRAIN)
-        token_spec = partition_manager.resolve([BATCH, LENGTH], MODE_TRAIN)
-        # Pad leading [batch, seq] for shard_map divisibility; padded rows carry zero weight (masked mean).
-        _pads = _vp_leading_pads(student_mtp_logits.shape[:-1], token_spec, vp_mesh)
-        _s = student_mtp_logits
-        _t = jax.lax.stop_gradient(teacher_target)
-        if any(_pads):
-            _s = _pad_leading(student_mtp_logits, _pads)
-            _t = _pad_leading(_t, _pads)
-            kl_weights = _pad_leading(kl_weights, _pads, fill=0.0)
-        out = _fused_kl(
-            _s,
-            _t,
-            kl_weights,
-            reduction="mean",
-            direction="forward",
-            temperature=temperature,
-            platform="xla",
-            mesh=vp_mesh,
-            in_specs=(logit_spec, logit_spec, token_spec),
-            out_specs=PartitionSpec(),
-        )
+    # Vocab-parallel KL via shard_map (same mechanism as ``distillation_loss``): keeps the vocab
+    # TP-sharded so the full [B, S, V] MTP logits are never all-reduced.
+    vp_mesh = _resolve_vocab_parallel_mesh(partition_manager)
+
+    def _run_mtp_kl(direction: str, beta_value: float = 0.5) -> Array:
+        if vp_mesh is not None:
+            kl_weights = mtp_mask if mtp_mask is not None else jnp.ones(student_mtp_logits.shape[:-1], dtype=jnp.float32)
+            logit_spec = partition_manager.resolve([BATCH, LENGTH, VOCAB], MODE_TRAIN)
+            token_spec = partition_manager.resolve([BATCH, LENGTH], MODE_TRAIN)
+            # Pad leading [batch, seq] for shard_map divisibility; padded rows carry zero weight.
+            _pads = _vp_leading_pads(student_mtp_logits.shape[:-1], token_spec, vp_mesh)
+            _s = student_mtp_logits
+            _t = jax.lax.stop_gradient(teacher_target)
+            if any(_pads):
+                _s = _pad_leading(student_mtp_logits, _pads)
+                _t = _pad_leading(_t, _pads)
+                kl_weights = _pad_leading(kl_weights, _pads, fill=0.0)
+            out = _fused_kl(
+                _s,
+                _t,
+                kl_weights,
+                reduction="mean",
+                direction=direction,
+                temperature=temperature,
+                beta=float(beta_value),
+                platform="xla",
+                mesh=vp_mesh,
+                in_specs=(logit_spec, logit_spec, token_spec),
+                out_specs=PartitionSpec(),
+            )
+        else:
+            out = _fused_kl(
+                student_mtp_logits,
+                jax.lax.stop_gradient(teacher_target),
+                mtp_mask,
+                reduction="mean",
+                direction=direction,
+                temperature=temperature,
+                beta=float(beta_value),
+                return_teacher_entropy=False,
+                platform="xla",
+            )
         return out.loss.astype(dtype)
 
-    out = _fused_kl(
-        student_mtp_logits,
-        jax.lax.stop_gradient(teacher_target),
-        mtp_mask,
-        reduction="mean",
-        direction=direction,
-        temperature=temperature,
-        beta=(0.5 if beta is None else float(beta)),
-        return_teacher_entropy=False,
-        platform="xla",
-    )
-    return out.loss.astype(dtype)
+    if cakld_gamma is not None:
+        gamma_s = jnp.asarray(float(cakld_gamma), dtype=jnp.float32)
+        forward_kl = _run_mtp_kl("forward")
+        reverse_kl = _run_mtp_kl("reverse")
+        return (gamma_s * reverse_kl + (jnp.asarray(1.0, dtype=jnp.float32) - gamma_s) * forward_kl).astype(dtype)
+
+    return _run_mtp_kl(direction, 0.5 if beta is None else float(beta))
 
 
 def mtp_chain_distillation_loss(
@@ -815,6 +849,7 @@ def mtp_chain_distillation_loss(
     loss_mask: Array | None = None,
     temperature: float = 4.0,
     beta: float | None = None,
+    cakld_gamma: float | None = None,
     partition_manager: tp.Any = None,
 ) -> tuple[Array, list[Array]]:
     """Multi-step soft KD for a recursively-applied MTP head (FastMTP-style).
@@ -834,6 +869,7 @@ def mtp_chain_distillation_loss(
         attention_mask / loss_mask: ``(B, S)`` masks (loss_mask takes priority).
         temperature: Shared softmax temperature.
         beta: Divergence selector (see :func:`distillation_loss`).
+        cakld_gamma: Optional CAKLD coefficient. Mutually exclusive with ``beta``.
 
     Returns:
         ``(mean_kd_over_steps, [per_step_kd, ...])``.
@@ -842,22 +878,70 @@ def mtp_chain_distillation_loss(
     n_steps, b, s, _ = chain_logits.shape
     base = loss_mask if loss_mask is not None else attention_mask
     base = base.astype(dtype) if base is not None else None
-    if beta is None or beta <= 0.0:
+    if cakld_gamma is not None:
+        gamma = float(cakld_gamma)
+        if not 0.0 <= gamma <= 1.0:
+            raise ValueError("`cakld_gamma` must be within [0, 1] when set.")
+        if beta is not None:
+            raise ValueError("`cakld_gamma` is mutually exclusive with GJSD `beta`.")
+    elif beta is None or beta <= 0.0:
         direction = "forward"  # GKD/TRL beta->0 limit (and the classic-KD default)
     elif beta >= 1.0:
         direction = "reverse"  # GKD/TRL beta->1 limit
     else:
         direction = "jsd"
 
-    # Vocab-parallel forward KL via shard_map (forward direction only -- the kernel's vocab-parallel
-    # direction); keeps each step's [B, S, V] logits TP-sharded with no all-reduce. Same mesh/specs for
-    # every step. reverse/JSD fall through to the dense path.
-    vp_mesh = _resolve_vocab_parallel_mesh(partition_manager) if direction == "forward" else None
+    # Vocab-parallel KL via shard_map keeps each step's [B, S, V] logits TP-sharded with no all-reduce.
+    vp_mesh = _resolve_vocab_parallel_mesh(partition_manager)
     vp_logit_spec = partition_manager.resolve([BATCH, LENGTH, VOCAB], MODE_TRAIN) if vp_mesh is not None else None
     vp_token_spec = partition_manager.resolve([BATCH, LENGTH], MODE_TRAIN) if vp_mesh is not None else None
 
     per_step: list[Array] = []
     total = jnp.zeros((), dtype)
+
+    def _run_chain_kl(
+        step_logits: Array,
+        target_logits: Array,
+        mask: Array | None,
+        direction: str,
+        beta_value: float = 0.5,
+    ) -> Array:
+        if vp_mesh is not None:
+            kl_weights = mask if mask is not None else jnp.ones(step_logits.shape[:-1], dtype=jnp.float32)
+            _pads = _vp_leading_pads(step_logits.shape[:-1], vp_token_spec, vp_mesh)
+            _cs = step_logits
+            _ct = jax.lax.stop_gradient(target_logits)
+            if any(_pads):
+                _cs = _pad_leading(step_logits, _pads)
+                _ct = _pad_leading(_ct, _pads)
+                kl_weights = _pad_leading(kl_weights, _pads, fill=0.0)
+            out = _fused_kl(
+                _cs,
+                _ct,
+                kl_weights,
+                reduction="mean",
+                direction=direction,
+                temperature=temperature,
+                beta=float(beta_value),
+                platform="xla",
+                mesh=vp_mesh,
+                in_specs=(vp_logit_spec, vp_logit_spec, vp_token_spec),
+                out_specs=PartitionSpec(),
+            )
+        else:
+            out = _fused_kl(
+                step_logits,
+                jax.lax.stop_gradient(target_logits),
+                mask,
+                reduction="mean",
+                direction=direction,
+                temperature=temperature,
+                beta=float(beta_value),
+                return_teacher_entropy=False,
+                platform="xla",
+            )
+        return out.loss.astype(dtype)
+
     for j in range(int(n_steps)):
         k = j + 1
         # teacher target for step k = teacher_logits shifted left by k (pad tail, masked).
@@ -867,41 +951,15 @@ def mtp_chain_distillation_loss(
             mask = jnp.concatenate([base[:, k + 1 :], jnp.zeros((b, k + 1), dtype=dtype)], axis=1)[:, :s]
         else:
             mask = None
-        if vp_mesh is not None:
-            kl_weights = mask if mask is not None else jnp.ones(chain_logits[j].shape[:-1], dtype=jnp.float32)
-            # Pad leading [batch, seq] for shard_map divisibility; padded rows carry zero weight (masked mean).
-            _pads = _vp_leading_pads(chain_logits[j].shape[:-1], vp_token_spec, vp_mesh)
-            _cs = chain_logits[j]
-            _ct = jax.lax.stop_gradient(teacher_target)
-            if any(_pads):
-                _cs = _pad_leading(chain_logits[j], _pads)
-                _ct = _pad_leading(_ct, _pads)
-                kl_weights = _pad_leading(kl_weights, _pads, fill=0.0)
-            out = _fused_kl(
-                _cs,
-                _ct,
-                kl_weights,
-                reduction="mean",
-                direction="forward",
-                temperature=temperature,
-                platform="xla",
-                mesh=vp_mesh,
-                in_specs=(vp_logit_spec, vp_logit_spec, vp_token_spec),
-                out_specs=PartitionSpec(),
+        if cakld_gamma is not None:
+            gamma_s = jnp.asarray(float(cakld_gamma), dtype=jnp.float32)
+            forward_kl = _run_chain_kl(chain_logits[j], teacher_target, mask, "forward")
+            reverse_kl = _run_chain_kl(chain_logits[j], teacher_target, mask, "reverse")
+            step_loss = (gamma_s * reverse_kl + (jnp.asarray(1.0, dtype=jnp.float32) - gamma_s) * forward_kl).astype(
+                dtype
             )
         else:
-            out = _fused_kl(
-                chain_logits[j],
-                jax.lax.stop_gradient(teacher_target),
-                mask,
-                reduction="mean",
-                direction=direction,
-                temperature=temperature,
-                beta=(0.5 if beta is None else float(beta)),
-                return_teacher_entropy=False,
-                platform="xla",
-            )
-        step_loss = out.loss.astype(dtype)
+            step_loss = _run_chain_kl(chain_logits[j], teacher_target, mask, direction, 0.5 if beta is None else beta)
         per_step.append(step_loss)
         total = total + step_loss
     return total / jnp.asarray(n_steps, dtype), per_step
@@ -1264,6 +1322,7 @@ def distillation_step(
     logits_chunk_size: int | None = None,
     checkpoint_kl_loss: bool = True,
     beta: float | None = None,
+    cakld_gamma: float | None = None,
     loss_top_k: int = 0,
     loss_add_tail: bool = False,
     mtp_distillation: bool = False,
@@ -1335,7 +1394,7 @@ def distillation_step(
 
     request_hidden_states = hidden_state_weight != 0.0
     request_attentions = attention_weight != 0.0
-    use_advanced_vocab_loss = beta is not None or loss_top_k > 0 or loss_add_tail
+    use_advanced_vocab_loss = beta is not None or cakld_gamma is not None or loss_top_k > 0 or loss_add_tail
     use_chunked = logits_chunk_size is not None and logits_chunk_size > 0 and not use_advanced_vocab_loss
 
     _stage_mesh = spx.get_current_stage_mesh(
@@ -1518,6 +1577,7 @@ def distillation_step(
                 temperature=temperature,
                 alpha=alpha,
                 beta=beta,
+                cakld_gamma=cakld_gamma,
                 loss_top_k=loss_top_k,
                 loss_add_tail=loss_add_tail,
                 partition_manager=partition_manager,
@@ -1554,6 +1614,7 @@ def distillation_step(
                         loss_mask=completion_mask,
                         temperature=temperature,
                         beta=beta,
+                        cakld_gamma=cakld_gamma,
                         partition_manager=spx.PartitionManager(paxis=module.config.partition_axis),
                     )
                     mtp_kd_value = mtp_kd_value.astype(total_loss.dtype)
@@ -1571,6 +1632,7 @@ def distillation_step(
                         loss_mask=completion_mask,
                         temperature=temperature,
                         beta=beta,
+                        cakld_gamma=cakld_gamma,
                         partition_manager=spx.PartitionManager(paxis=module.config.partition_axis),
                     )
                     mtp_kd_value = mtp_kd_value.astype(total_loss.dtype)
@@ -1703,6 +1765,7 @@ def _distillation_scheduled_loss_cache_key(call) -> tuple[tp.Any, ...]:
             "logits_chunk_size",
             "checkpoint_kl_loss",
             "beta",
+            "cakld_gamma",
             "loss_top_k",
             "loss_add_tail",
         ),
@@ -1736,9 +1799,10 @@ def _make_distillation_scheduled_loss(call):
     logits_chunk_size = call.get("logits_chunk_size")
     checkpoint_kl_loss = bool(call.get("checkpoint_kl_loss", True))
     beta = call.get("beta")
+    cakld_gamma = call.get("cakld_gamma")
     loss_top_k = int(call.get("loss_top_k", 0) or 0)
     loss_add_tail = bool(call.get("loss_add_tail", False))
-    use_advanced_vocab_loss = beta is not None or loss_top_k > 0 or loss_add_tail
+    use_advanced_vocab_loss = beta is not None or cakld_gamma is not None or loss_top_k > 0 or loss_add_tail
     use_chunked = logits_chunk_size is not None and logits_chunk_size > 0 and not use_advanced_vocab_loss
     request_hidden_states = hidden_state_weight != 0.0
     request_attentions = attention_weight != 0.0
@@ -1816,6 +1880,10 @@ def _make_distillation_scheduled_loss(call):
                     checkpoint_chunks=checkpoint_kl_loss,
                 )
             else:
+                partition_manager = None
+                stage_mesh = spx.get_current_stage_mesh(getattr(module, "mesh", None), raise_error=False)
+                if stage_mesh is not None and "tp" in stage_mesh.axis_names and stage_mesh.shape["tp"] > 1:
+                    partition_manager = spx.PartitionManager(paxis=module.config.partition_axis)
                 total_loss, _loss_components = distillation_loss(
                     student_logits=student_outputs["logits"],
                     teacher_logits=teacher_outputs["logits"],
@@ -1826,8 +1894,10 @@ def _make_distillation_scheduled_loss(call):
                     temperature=temperature,
                     alpha=alpha,
                     beta=beta,
+                    cakld_gamma=cakld_gamma,
                     loss_top_k=loss_top_k,
                     loss_add_tail=loss_add_tail,
+                    partition_manager=partition_manager,
                 )
 
         if request_hidden_states:

--- a/libs/easydel/easydel/trainers/distillation_trainer/distillation_config.py
+++ b/libs/easydel/easydel/trainers/distillation_trainer/distillation_config.py
@@ -71,6 +71,10 @@ class DistillationConfig(TrainingArguments):
         alpha: Mixing weight on the distillation term. ``1.0`` is pure
             distillation; ``0.0`` is pure supervised CE. Must be in
             ``[0, 1]`` (validated in ``__post_init__``). Default ``0.9``.
+        cakld_gamma: Optional Confidence-Aware KL coefficient. When set,
+            enables ``gamma * KL(student || teacher) + (1 - gamma) *
+            KL(teacher || student)``. This should be the precomputed
+            averaged teacher-token confidence from the CAKLD paper.
         dataset_text_field: Field name read by the SFT-style
             tokenization fallback when the dataset is plain text.
             Default ``"text"``.
@@ -138,6 +142,16 @@ class DistillationConfig(TrainingArguments):
     beta: float | None = field(
         default=None,
         metadata={"help": "Optional generalized Jensen-Shannon interpolation coefficient in [0, 1]."},
+    )
+    cakld_gamma: float | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional Confidence-Aware KL gamma in [0, 1]. When set, the soft distillation term is "
+                "gamma * KL(student || teacher) + (1 - gamma) * KL(teacher || student). This value is "
+                "normally precomputed as the averaged teacher-token probability on a calibration subset."
+            )
+        },
     )
     reverse_kl_top_1_mode: tp.Literal["sampled", "argmax"] = field(
         default="sampled",
@@ -342,6 +356,12 @@ class DistillationConfig(TrainingArguments):
             raise ValueError("EasyDeL `DistillationTrainer` is offline-only; set `lmbda=0.0`.")
         if self.beta is not None and not 0.0 <= float(self.beta) <= 1.0:
             raise ValueError("`beta` must be within [0, 1] when set.")
+        if self.cakld_gamma is not None:
+            self.cakld_gamma = float(self.cakld_gamma)
+            if not 0.0 <= self.cakld_gamma <= 1.0:
+                raise ValueError("`cakld_gamma` must be within [0, 1] when set.")
+            if self.beta is not None:
+                raise ValueError("`cakld_gamma` is mutually exclusive with GJSD `beta`.")
         if self.reverse_kl_top_1_mode != "sampled":
             raise ValueError("`reverse_kl_top_1_mode` is only meaningful for TRL GJSD distillation.")
         self.loss_top_k = int(self.loss_top_k)
@@ -349,6 +369,8 @@ class DistillationConfig(TrainingArguments):
             raise ValueError("`loss_top_k` must be non-negative.")
         if self.loss_add_tail and self.loss_top_k <= 0:
             raise ValueError("`loss_add_tail=True` requires `loss_top_k > 0`.")
+        if self.cakld_gamma is not None and self.loss_top_k > 0:
+            raise ValueError("`cakld_gamma` is not supported with `loss_top_k` / `loss_add_tail`.")
         if self.max_prompt_length is not None:
             raise ValueError("`max_prompt_length` is not used by EasyDeL offline distillation; use `max_length`.")
         if self.max_completion_length is not None:

--- a/libs/easydel/easydel/trainers/distillation_trainer/distillation_trainer.py
+++ b/libs/easydel/easydel/trainers/distillation_trainer/distillation_trainer.py
@@ -286,6 +286,7 @@ class DistillationTrainer(Trainer):
         if _tp_size > 1:
             _adv_vocab = (
                 self.arguments.beta is not None
+                or self.arguments.cakld_gamma is not None
                 or int(self.arguments.loss_top_k or 0) > 0
                 or bool(self.arguments.loss_add_tail)
             )
@@ -347,6 +348,7 @@ class DistillationTrainer(Trainer):
             self.arguments.logits_chunk_size,
             bool(self.arguments.checkpoint_kl_loss),
             self.arguments.beta,
+            self.arguments.cakld_gamma,
             int(self.arguments.loss_top_k),
             bool(self.arguments.loss_add_tail),
             bool(self.arguments.mtp_distillation),
@@ -354,7 +356,7 @@ class DistillationTrainer(Trainer):
             int(self.arguments.mtp_draft_tokens),
         )
 
-        static_argnums = (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24)
+        static_argnums = (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)
         self._runtime_trace("train.compile_wrapper.begin")
         if self.arguments.mpmd_scheduler is None:
             sharded_training_step_function = spx.jit(
@@ -394,6 +396,7 @@ class DistillationTrainer(Trainer):
             self.arguments.logits_chunk_size,
             bool(self.arguments.checkpoint_kl_loss),
             self.arguments.beta,
+            self.arguments.cakld_gamma,
             int(self.arguments.loss_top_k),
             bool(self.arguments.loss_add_tail),
             bool(self.arguments.mtp_distillation),

--- a/libs/easydel/tests/trainers/test_distillation_loss_math.py
+++ b/libs/easydel/tests/trainers/test_distillation_loss_math.py
@@ -18,6 +18,7 @@ import jax
 import jax.numpy as jnp
 import optax  # pyright: ignore[reportMissingTypeStubs]
 import pytest
+
 from easydel.trainers.distillation_trainer._fn import chunked_distillation_loss, distillation_loss
 
 
@@ -309,6 +310,45 @@ def test_distillation_beta_endpoints_match_gkd_convention():
         beta=1.0,
     )
     assert jnp.allclose(metrics_rev["kl_loss"], jnp.mean(reverse_kl) * t_sq, atol=1e-5)
+
+
+def test_distillation_cakld_blends_forward_and_reverse_kl():
+    student_logits = jnp.array([[[1.0, 0.0, -0.5], [0.2, 0.5, -0.3]]], dtype=jnp.float32)
+    teacher_logits = jnp.array([[[0.1, 0.6, -0.2], [0.4, -0.1, 0.3]]], dtype=jnp.float32)
+    mask = jnp.array([[1, 0]], dtype=jnp.int32)
+    temperature = 1.5
+    gamma = 0.7
+
+    _, metrics = distillation_loss(
+        student_logits=student_logits,
+        teacher_logits=teacher_logits,
+        loss_mask=mask,
+        temperature=temperature,
+        alpha=1.0,
+        cakld_gamma=gamma,
+    )
+
+    student_log_probs = jax.nn.log_softmax(student_logits / temperature, axis=-1)
+    teacher_log_probs = jax.nn.log_softmax(teacher_logits / temperature, axis=-1)
+    forward_kl = jnp.sum(jnp.exp(teacher_log_probs) * (teacher_log_probs - student_log_probs), axis=-1)
+    reverse_kl = jnp.sum(jnp.exp(student_log_probs) * (student_log_probs - teacher_log_probs), axis=-1)
+    per_token = gamma * reverse_kl + (1.0 - gamma) * forward_kl
+    expected = jnp.sum(per_token * mask) / jnp.sum(mask) * (temperature**2)
+
+    assert jnp.allclose(metrics["kl_loss"], expected, atol=1e-6)
+    assert jnp.allclose(metrics["distill_xent_loss"], expected, atol=1e-6)
+    assert jnp.allclose(metrics["teacher_entropy_loss"], 0.0, atol=1e-6)
+
+
+def test_distillation_cakld_rejects_beta():
+    logits = jnp.array([[[1.0, 0.0, -0.5]]], dtype=jnp.float32)
+    with pytest.raises(ValueError, match="cakld_gamma"):
+        distillation_loss(
+            student_logits=logits,
+            teacher_logits=logits,
+            beta=0.5,
+            cakld_gamma=0.5,
+        )
 
 
 def test_gkd_jsd_beta_endpoints_match_trl_convention():

--- a/libs/easydel/tests/trainers/test_mtp_distillation.py
+++ b/libs/easydel/tests/trainers/test_mtp_distillation.py
@@ -137,6 +137,62 @@ def test_mtp_kd_mask():
     assert jnp.isfinite(loss), "masked loss must be finite"
 
 
+@_case("mtp_distillation_loss: CAKLD blends shifted forward/reverse KL")
+def test_mtp_kd_cakld_blend():
+    teacher = jnp.array(
+        [[[0.2, 0.5, -0.1], [0.7, -0.3, 0.1], [0.0, 0.4, 0.8], [-0.2, 0.3, 0.6]]],
+        dtype=jnp.float32,
+    )
+    student = jnp.array(
+        [[[0.1, 0.6, -0.2], [0.4, 0.0, 0.5], [0.3, -0.1, 0.2], [0.9, 0.2, -0.4]]],
+        dtype=jnp.float32,
+    )
+    temperature = 1.25
+    gamma = 0.35
+    loss = mtp_distillation_loss(
+        student,
+        teacher,
+        attention_mask=jnp.ones((1, 4), dtype=jnp.float32),
+        temperature=temperature,
+        cakld_gamma=gamma,
+    )
+
+    teacher_target = jnp.concatenate([teacher[:, 1:], teacher[:, -1:]], axis=1)
+    mtp_mask = jnp.array([[1.0, 1.0, 0.0, 0.0]], dtype=jnp.float32)
+    student_log_probs = jax.nn.log_softmax(student / temperature, axis=-1)
+    teacher_log_probs = jax.nn.log_softmax(teacher_target / temperature, axis=-1)
+    forward_kl = jnp.sum(jnp.exp(teacher_log_probs) * (teacher_log_probs - student_log_probs), axis=-1)
+    reverse_kl = jnp.sum(jnp.exp(student_log_probs) * (student_log_probs - teacher_log_probs), axis=-1)
+    expected = jnp.sum((gamma * reverse_kl + (1.0 - gamma) * forward_kl) * mtp_mask) / jnp.sum(mtp_mask)
+    expected = expected * (temperature**2)
+
+    assert jnp.allclose(loss, expected, atol=1e-6), f"CAKLD MTP loss mismatch: got={loss}, expected={expected}"
+
+
+@_case("mtp_chain_distillation_loss: CAKLD blends per-step forward/reverse KL")
+def test_mtp_chain_cakld_blend():
+    b, s, v, n_steps = 1, 6, 8, 3
+    teacher = jax.random.normal(jax.random.PRNGKey(7), (b, s, v), dtype=jnp.float32) * 0.5
+    chain = jax.random.normal(jax.random.PRNGKey(8), (n_steps, b, s, v), dtype=jnp.float32) * 0.5
+    am = jnp.ones((b, s), dtype=jnp.float32)
+    temperature, gamma = 1.5, 0.35
+
+    mean_cakld, per_cakld = mtp_chain_distillation_loss(
+        chain, teacher, attention_mask=am, temperature=temperature, cakld_gamma=gamma
+    )
+    # beta=None -> forward, beta=1.0 -> reverse (GKD/TRL convention).
+    mean_fwd, per_fwd = mtp_chain_distillation_loss(chain, teacher, attention_mask=am, temperature=temperature)
+    mean_rev, per_rev = mtp_chain_distillation_loss(
+        chain, teacher, attention_mask=am, temperature=temperature, beta=1.0
+    )
+
+    assert len(per_cakld) == n_steps
+    for j in range(n_steps):
+        expected = gamma * per_rev[j] + (1.0 - gamma) * per_fwd[j]
+        assert jnp.allclose(per_cakld[j], expected, atol=1e-6), f"chain step {j} CAKLD blend mismatch"
+    assert jnp.allclose(mean_cakld, gamma * mean_rev + (1.0 - gamma) * mean_fwd, atol=1e-6), "chain mean blend mismatch"
+
+
 @_case("compute_mtp_chain: shape + step-1 matches the single-step path")
 def test_mtp_chain_shape_and_consistency():
     b, s, v, k = 2, 32, 128, 6
@@ -201,6 +257,8 @@ ALL_TESTS = [
     test_mtp_kd_nonnegative,
     test_mtp_kd_perfect_match,
     test_mtp_kd_mask,
+    test_mtp_kd_cakld_blend,
+    test_mtp_chain_cakld_blend,
     test_mtp_chain_shape_and_consistency,
     test_mtp_chain_perfect_alignment,
     test_config_validation,

--- a/libs/ejkernel/test/kernels/_xla/test_fused_kl_divergence_sharding.py
+++ b/libs/ejkernel/test/kernels/_xla/test_fused_kl_divergence_sharding.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The EasyDeL/ejKernel Author @erfanzar (Erfan Zare Chavoshi).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""XLA vocab-parallel (shard_map) KL direction parity.
+
+The public ``fused_kl_divergence`` documents that its ``mesh`` / ``in_specs``
+path supports ``forward`` / ``reverse`` / ``jsd`` over a sharded vocab axis
+(not just forward). EasyDeL's distillation loss relies on this: it routes
+``reverse`` / ``jsd`` (and the CAKLD ``gamma*reverse + (1-gamma)*forward``
+blend) through the vocab-parallel path under TP. This test pins that contract
+so a future kernel change cannot silently drop the per-shard normalizer from
+the reverse/JSD VJP (the exact class of bug ``check_vma`` exists to prevent).
+
+CPU-runnable; force devices in the shell before pytest (a conftest may import
+jax first, so the ``setdefault`` below is best-effort only)::
+
+    XLA_FLAGS=--xla_force_host_platform_device_count=4 JAX_PLATFORMS=cpu \\
+    pytest libs/ejkernel/test/kernels/_xla/test_fused_kl_divergence_sharding.py
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=4")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.experimental import mesh_utils
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+
+from ejkernel.modules.operations import fused_kl_divergence
+
+if jax.device_count() < 2:
+    pytest.skip(
+        "needs >=2 devices for the tp=2 vocab-parallel cases — set "
+        "XLA_FLAGS=--xla_force_host_platform_device_count=4 (with JAX_PLATFORMS=cpu) "
+        "in the shell before pytest starts",
+        allow_module_level=True,
+    )
+
+B, S, V, TEMP = 2, 6, 8, 2.5
+LOGIT_SPEC = P(None, None, "tp")
+TOKEN_SPEC = P(None, None)
+
+
+def _inputs():
+    ks, kt, km = jax.random.split(jax.random.PRNGKey(0), 3)
+    student = jax.random.normal(ks, (B, S, V), jnp.float32)
+    teacher = jax.random.normal(kt, (B, S, V), jnp.float32)
+    mask = jax.random.uniform(km, (B, S), jnp.float32, minval=0.2, maxval=1.0)
+    return student, teacher, mask
+
+
+def _mesh():
+    return Mesh(mesh_utils.create_device_mesh((jax.device_count(),)), ("tp",))
+
+
+def _dense(student, teacher, mask, direction, beta=0.5):
+    return fused_kl_divergence(
+        student, teacher, mask, reduction="mean", direction=direction,
+        temperature=TEMP, beta=beta, platform="xla",
+    ).loss
+
+
+def _sharded(student, teacher, mask, mesh, direction, beta=0.5):
+    return fused_kl_divergence(
+        student, teacher, mask, reduction="mean", direction=direction,
+        temperature=TEMP, beta=beta, platform="xla",
+        mesh=mesh, in_specs=(LOGIT_SPEC, LOGIT_SPEC, TOKEN_SPEC), out_specs=P(),
+    ).loss
+
+
+@pytest.mark.parametrize("direction", ["forward", "reverse", "jsd"])
+def test_xla_vocab_parallel_kl_direction_value_parity(direction):
+    """Sharded vocab-parallel KL matches the dense value for every direction."""
+    student, teacher, mask = _inputs()
+    mesh = _mesh()
+    with mesh:
+        ref = _dense(student, teacher, mask, direction)
+        got = _sharded(student, teacher, mask, mesh, direction)
+    np.testing.assert_allclose(np.asarray(got), np.asarray(ref), rtol=0.0, atol=1e-5)
+
+
+@pytest.mark.parametrize("direction", ["forward", "reverse", "jsd"])
+def test_xla_vocab_parallel_kl_direction_grad_parity(direction):
+    """The vocab-parallel reverse/JSD VJP (via forced ``check_vma``) matches dense."""
+    student, teacher, mask = _inputs()
+    mesh = _mesh()
+    grad_ref = jax.grad(lambda s: _dense(s, teacher, mask, direction))(student)
+    with mesh:
+        grad_got = jax.grad(lambda s: _sharded(s, teacher, mask, mesh, direction))(student)
+    np.testing.assert_allclose(np.asarray(grad_got), np.asarray(grad_ref), rtol=0.0, atol=1e-5)
+
+
+def test_xla_vocab_parallel_cakld_blend_parity():
+    """The CAKLD ``gamma*reverse + (1-gamma)*forward`` blend matches dense under TP."""
+    student, teacher, mask = _inputs()
+    mesh = _mesh()
+    gamma = 0.7
+    ref = gamma * _dense(student, teacher, mask, "reverse") + (1.0 - gamma) * _dense(student, teacher, mask, "forward")
+    with mesh:
+        got = (
+            gamma * _sharded(student, teacher, mask, mesh, "reverse")
+            + (1.0 - gamma) * _sharded(student, teacher, mask, mesh, "forward")
+        )
+    np.testing.assert_allclose(np.asarray(got), np.asarray(ref), rtol=0.0, atol=1e-5)


### PR DESCRIPTION
## Summary

Adds an optional `cakld_gamma` coefficient to the distillation trainer that blends forward and reverse KL:

```
gamma * KL(p_student ‖ p_teacher) + (1 - gamma) * KL(p_teacher ‖ p_student)
```

`gamma` is the precomputed averaged teacher-token confidence (Confidence-Aware Knowledge Distillation).
- `gamma = 0` → classic forward KD
- `gamma = 1` → pure reverse KL
- intermediate → interpolation

This complements the existing generalized-JSD `beta` knob. The two are mutually exclusive (validated).

## Motivation

CAKLD lets the distillation objective adapt per-run to teacher confidence: forward KL (mode-covering) where the teacher is uncertain, reverse KL (mode-seeking) where it is confident. A single scalar `gamma` (precomputed from a calibration subset) controls the blend, with no per-token overhead beyond a second fused-KL reduction.

## Changes

**Loss functions** (`distillation_trainer/_fn.py`)
- `distillation_loss`, `mtp_distillation_loss`, `mtp_chain_distillation_loss`: new `cakld_gamma` param; runs two fused-KL reductions (forward + reverse) and blends. Mutually exclusive with `beta` and with `loss_top_k`/`loss_add_tail` (validated in both the loss fns and `DistillationConfig.__post_init__`).
- `distillation_step` + scheduled-loss path: `cakld_gamma` threaded through; `static_argnums` and the scheduled-loss cache key updated consistently.
- Removed the forward-only guard on the vocab-parallel `shard_map` path: the ejkernel XLA backend already supports forward/reverse/JSD over a sharded vocab axis (with forced `check_vma` for an exact reverse/JSD gradient), so reverse/JSD now flow through the TP path too. The scheduled path now builds the vocab-parallel `PartitionManager` the same way as the eager path.

**Config** (`distillation_config.py`, `infra/elarge/types/training.py`)
- `DistillationConfig.cakld_gamma` field + validation.
- `DistillationTrainerCfg` typed key + default.

**Tests**
- `distillation_loss` CAKLD blend value (hand-derived, T² scaling) + `beta` mutual-exclusion rejection.
- `mtp_distillation_loss` CAKLD blend (hand-derived shifted forward/reverse).
- `mtp_chain_distillation_loss` CAKLD per-step + mean blend composition.
- New `libs/ejkernel/test/kernels/_xla/test_fused_kl_divergence_sharding.py`: forward/reverse/JSD value+grad parity and the CAKLD blend under `shard_map` vs dense (CPU-runnable; pins the kernel contract this feature relies on).

## Verification

- All distillation + MTP tests pass (22 easydel + 7 ejkernel guard).
- `ruff check` clean on all touched files.
- Vocab-parallel reverse/JSD/CAKLD proven equal to dense in **value and gradient** (CPU, tp=4; max grad diff < 3e-8).

## Notes

- The ejkernel guard test can be split into a separate PR if preferred; included here because it protects the kernel contract the feature depends on.
- Pre-existing minor import-sort nit (`I001`) in `test_distillation_loss_math.py` cleaned up since the PR touches that file.
