### PR TITLE
fix(spectrax): restore the URI scheme in find_latest_checkpoint

### DIFF
--- a/libs/spectrax/spectrax/serialization/checkpointer.py
+++ b/libs/spectrax/spectrax/serialization/checkpointer.py
@@ -560,7 +560,22 @@ def find_latest_checkpoint(base_path: str) -> str | None:
     if not _fs.is_dir(base_path):
         return None
 
-    candidates = [p for p in _fs.iterdir(base_path) if _fs.is_dir(p)]
+    # ``_fs.iterdir()`` returns paths with the URI scheme stripped
+    # ("gs://bucket/run" -> "bucket/run"). Every subsequent path operation --
+    # including the metadata.json existence probe below -- then resolves against
+    # the LOCAL filesystem and is unconditionally False for remote object
+    # storage, so discovery silently returns None and resumption never happens.
+    # Re-attach the scheme taken from ``base_path`` before touching the results.
+    _scheme = base_path.split("://", 1)[0] + "://" if "://" in base_path else ""
+
+    def _restore_scheme(path: str) -> str:
+        if not _scheme or path.startswith(_scheme):
+            return path
+        return _scheme + path.lstrip("/")
+
+    candidates = [
+        q for q in (_restore_scheme(p) for p in _fs.iterdir(base_path)) if _fs.is_dir(q)
+    ]
     candidates.append(base_path)
 
     ckpts = [p for p in candidates if _fs.exists(_fs.joinpath(p, "metadata.json"))]


### PR DESCRIPTION
## The bug

`_fs.iterdir()` returns paths with the URI scheme stripped — `gs://bucket/run` comes back as `bucket/run`. `find_latest_checkpoint` then probes for `metadata.json` on those bare paths, which resolves against the **local** filesystem and is always False for remote object storage. Discovery returns `None` and `resume_if_possible` silently never resumes.

The failure is invisible: callers see "no checkpoint found" and start from scratch. On preemptible hardware with checkpoints in object storage this fires at every preemption, so a long run repeatedly discards its optimizer state without reporting anything.

## The fix

Re-attach the scheme taken from `base_path` before the `is_dir()` filter and the metadata probe. Local paths are unaffected (no scheme to restore).

## Verification

Reproduced end-to-end against a live GCS bucket with three synthetic checkpoints (`run-100/200/300`, each with valid `metadata.json` carrying `timestamp` and `step`):

| | result |
|---|---|
| current vnext | `None` — finds nothing |
| patched | `gs://…/run-300` — the newest, correctly |

Also verified directly that `is_dir(bare_path)` → False while `is_dir(scheme_restored)` → True on the same entries, which is the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)