### PR TITLE
fix(easydel): recognize both jax wordings for a treedef mismatch

### DIFF
--- a/libs/easydel/easydel/infra/base_state.py
+++ b/libs/easydel/easydel/infra/base_state.py
@@ -329,7 +329,19 @@ def _optimizer_state_shardings_from_params(
             )
             return _sanitize_slot_shardings(slot_shardings)
         except ValueError as exc:
-            if "Mismatch custom node data" not in str(exc):
+            # jax phrases a treedef mismatch differently across versions:
+            # "Mismatch custom node data" before 0.10, "different pytree
+            # metadata" / "pytree structure error" from 0.10 on. Matching only
+            # the old wording means that on current jax the exception escapes
+            # instead of falling through to the structural path below, so any
+            # optimizer whose pytree node definition carries value-dependent
+            # static aux_data fails here rather than being handled.
+            _mismatch_markers = (
+                "Mismatch custom node data",
+                "different pytree metadata",
+                "pytree structure error",
+            )
+            if not any(m in str(exc) for m in _mismatch_markers):
                 raise
 
     param_treedef = jax.tree_util.tree_structure(param_shardings, is_leaf=_is_sharding_leaf)


### PR DESCRIPTION
## The bug

`base_state` calls `optax.tree_map_params` for sharding inference and catches the treedef mismatch that occurs when a transform's state pytree carries value-dependent static aux_data (tree_map_params re-initialises the transform with placeholder params, so the aux_data differs). On a match it falls through to the structural sharding path.

The guard matches only the string `"Mismatch custom node data"`. But jax raises this mismatch with **different wordings from different code paths in the same release**:

- `treedef.flatten_up_to` → `Mismatch custom node data: …`
- `tree_map` / `tree_transpose` → `pytree structure error: different pytree metadata at key path …`

`optax.tree_map_params` goes through `tree_map`, so the guard misses **exactly the path it sits on** — the ValueError escapes and sharding inference fails outright instead of using the structural fallback.

## Verification

jax 0.10.2 / optax 0.2.8, with a minimal transform whose state carries value-dependent aux_data:

- the real `optax.tree_map_params` exception carries the `pytree structure error` wording
- current guard: **re-raises** → sharding inference dies
- broadened guard: falls through to the structural path, which assigns param shardings to matching slots and replicates the rest (unchanged logic)

## The fix

Match all known wordings. The structural fallback itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)