### PR TITLE
feat(eformer): EFORMER_DISABLE_FORKIFY to run inline

### DIFF
--- a/libs/eformer/eformer/executor/ray/resource_manager.py
+++ b/libs/eformer/eformer/executor/ray/resource_manager.py
@@ -276,6 +276,15 @@ class RayResources:
                 info = ExceptionInfo.ser_exc_info(e)
                 queue.put((False, info))
 
+        # Escape hatch: run inline in this process instead of forking. When the
+        # child dies hard the parent can only report a generic timeout and the
+        # real traceback is lost, which makes accelerator-init failures hard to
+        # diagnose; this propagates the original exception instead. Checked here,
+        # in the parent, before the process exists -- inside the child body it
+        # could not prevent the fork.
+        if os.getenv("EFORMER_DISABLE_FORKIFY"):
+            return underlying_function(*args, **kwargs)
+
         queue = multiprocessing.Queue()
         process = multiprocessing.Process(target=target_fn, args=(queue, args, kwargs))
         timeout_s = float(os.getenv("EFORMER_SUBPROCESS_TIMEOUT_S", "1000000"))


### PR DESCRIPTION
## Motivation

`separate_process_fn` runs the wrapped function in a child process. When the child dies hard (e.g. during accelerator init), the parent can only report a generic `Process timed out` — the original traceback is lost, which makes these failures needlessly hard to diagnose.

## The change

Setting `EFORMER_DISABLE_FORKIFY` skips the fork and runs the function inline in the calling process, so the real exception propagates with its full frames. The check sits in the parent, before the `Process` is created.

Default behaviour is unchanged: the variable is opt-in and unset means fork as before.

## Verification

| | pid | result | exception surface |
|---|---|---|---|
| flag unset | child pid | 42 | re-wrapped `ExceptionInfo(…)` summary |
| flag set | caller's pid | 42 | original `ValueError` with full frames |

🤖 Generated with [Claude Code](https://claude.com/claude-code)